### PR TITLE
Add new release candidate 2018-08-27

### DIFF
--- a/obi_core.owl
+++ b/obi_core.owl
@@ -12,7 +12,7 @@
      xmlns:foaf="http://xmlns.com/foaf/0.1/"
      xmlns:dc="http://purl.org/dc/elements/1.1/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/obi/obi_core.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/obi/2018-06-25/obi_core.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/obi/2018-08-27/obi_core.owl"/>
         <protege:defaultLanguage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">en</protege:defaultLanguage>
         <obo:IAO_0000589 xml:lang="en">Ontology for Biomedical Investigations</obo:IAO_0000589>
         <dc:contributor xml:lang="en">Advisors for this project come from the IFOMIS group, Saarbruecken and from the Co-ODE group in Manchester</dc:contributor>
@@ -78,7 +78,7 @@
         <dc:subject xml:lang="en">An ontology for the annotation of biomedical and functional genomics experiments.</dc:subject>
         <terms:license>http://creativecommons.org/licenses/by/4.0/</terms:license>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Please cite the OBI consortium http://purl.obolibrary.org/obo/obi where traditional citation is called for. However it is adequate that individual terms be attributed simply by use of the identifying PURL for the term, in projects that refer to them.</rdfs:comment>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2018-06-25</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2018-08-27</owl:versionInfo>
     </owl:Ontology>
     
 


### PR DESCRIPTION
All assays have been moved into a template (#943). Many assay labels have been clarified, logical definitions have been standardized, and annotations updated.

The are 17 new classes:

- OBI:0002565 adapter-sequence trimming
- OBI:0002566 file merge
- OBI:0002567 sequence alignment
- OBI:0002568 sequence data feature count tabulation
- OBI:0002569 trimmed sequence data
- OBI:0002578 adapter sequence data
- OBI:0002579 adapter-trimmed sequence data
- OBI:0002580 aligned sequence data
- OBI:0002581 merged aligned sequence data
- OBI:0002582 sequence library feature count data
- OBI:0002583 DNA methylation profiling data
- OBI:0002584 differential expression analysis data
- OBI:0002585 sequence trimming
- OBI:0002586 digital acquisition card
- OBI:0002587 machine learning
- OBI:0002588 supervised machine learning
- OBI:0002589 unsupervised machine learning