### PR TITLE
added obo:OMIABIS_0001019 to onfofox template for issue #971

### DIFF
--- a/src/ontology/OntoFox_inputs/OBO_input.txt
+++ b/src/ontology/OntoFox_inputs/OBO_input.txt
@@ -450,10 +450,13 @@ OMIABIS
 
 [Low level source term URIs]
 http://purl.obolibrary.org/obo/OMIABIS_0000052
+http://purl.obolibrary.org/obo/OMIABIS_0001019
 
 [Top level source term URIs and target direct superclass URIs]
 http://purl.obolibrary.org/obo/OMIABIS_0000050
 subClassOf http://purl.obolibrary.org/obo/OBI_0000953
+http://purl.obolibrary.org/obo/OMIABIS_0001019
+subClassOf http://purl.obolibrary.org/obo/OBI_0500000
 
 [Source term retrieval setting]
 includeAllIntermediates


### PR DESCRIPTION
sorry I didn't catch this sooner... do we really need to import this into OBI?  It is already present in OMIABIS, although not with the exact same term annotations.

Would the requester be satisfied using this term by importing OMIABIS into their workspace along with OBI?  Check for a response in the original issue #971