### PR TITLE
Module violation test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,8 @@ build/modules/%.owl: src/ontology/modules/%.owl | build/robot.jar
 build/modules/merged.owl: src/ontology/obi-edit.owl $(PHONY_MODULES) | build/robot.jar
 	$(eval INPUTS := $(foreach x,$(PHONY_MODULES),--input $(x) ))
 	$(ROBOT) remove --input $< --select imports \
-	merge $(INPUTS) --output $@
+	merge $(INPUTS) \
+	reason --output $@
 
 # Run all validation queries and exit on error.
 .PHONY: verify

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,8 @@ obi_core.owl: obi.owl src/ontology/core.txt | build/robot.jar
 #
 # Run main tests
 MERGED_VIOLATION_QUERIES := $(wildcard src/sparql/*-violation.rq) 
-EDIT_VIOLATION_QUERIES := $(wildcard src/sparql/*-violation-edit.rq)
+MODULE_VIOLATION_QUERIES := $(wildcard src/sparql/*-violation-modules.rq)
+PHONY_MODULES := $(foreach x,$(MODULE_NAMES),build/modules/$(x).owl)
 
 build/terms-report.csv: build/obi_merged.owl src/sparql/terms-report.rq | build
 	$(ROBOT) query --input $< --select $(word 2,$^) $@
@@ -188,15 +189,29 @@ build/current-entities.tsv: build/obi_merged.owl src/sparql/get-obi-entities.rq 
 build/dropped-entities.tsv: build/released-entities.tsv build/current-entities.tsv
 	comm -23 $^ > $@
 
+# Directory for phony modules
+build/modules:
+	mkdir -p build/modules
+
+# Remove all annotation properties from modules
+build/modules/%.owl: src/ontology/modules/%.owl | build/robot.jar
+	$(ROBOT) remove --input $< --select annotation-properties --output $@
+
+# Build OBI edit + modules without annotation properties
+build/modules/merged.owl: src/ontology/obi-edit.owl $(PHONY_MODULES) | build/robot.jar
+	$(eval INPUTS := $(foreach x,$(PHONY_MODULES),--input $(x) ))
+	$(ROBOT) remove --input $< --select imports \
+	merge $(INPUTS) --output $@
+
 # Run all validation queries and exit on error.
 .PHONY: verify
-verify: verify-edit verify-merged verify-entities
+verify: verify-modules verify-merged verify-entities
 
-# Run validation queries on obi-edit and exit on error.
-.PHONY: verify-edit
-verify-edit: src/ontology/obi-edit.owl $(EDIT_VIOLATION_QUERIES) | build/robot.jar
+# Run validation queries on merged modules and exit on error.
+.PHONY: verify-modules
+verify-modules: build/modules/merged.owl $(MODULE_VIOLATION_QUERIES) | build/robot.jar
 	$(ROBOT) verify --input $< --output-dir build \
-	--queries $(EDIT_VIOLATION_QUERIES)
+	--queries $(MODULE_VIOLATION_QUERIES)
 
 # Run validation queries on obi_merged and exit on error.
 .PHONY: verify-merged

--- a/src/sparql/assay-violation-modules.rq
+++ b/src/sparql/assay-violation-modules.rq
@@ -1,9 +1,11 @@
 # 'assay' should have no asserted children in obi-edit.owl
+# Any descendant of assay that has a label is asserted in obi-edit.owl
 
 PREFIX obo:  <http://purl.obolibrary.org/obo/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?s WHERE {
-	?s rdfs:subClassOf* obo:OBI_0000070 .
+	?s rdfs:subClassOf* obo:OBI_0000070 ;
+	   rdfs:label ?label .
 	FILTER (str(?s) != "http://purl.obolibrary.org/obo/OBI_0000070")
 }


### PR DESCRIPTION
Check for 'assay' module violations (and we can add in other module tests) by removing all annotation properties from the modules and then merging into `obi-edit.owl` without imports. Then, look for any descendant of 'assay' that has a label.