### PR TITLE
Create candidate task to make PR for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ sort: src/ontology/templates/
 # Requires "admin:org", "repo", and "workflow" permissions for gh CLI token
 .PHONY: candidate
 candidate: obi.owl views build/new-entities.txt
-	$(eval REMOTE := $(shell git remote -v | grep "https://github.com/obi-ontology/obi.git" | head -1 | cut -f 1))
+	$(eval REMOTE := $(shell git remote -v | grep "obi-ontology/obi.git" | head -1 | cut -f 1))
 	git checkout -b $(TODAY)
 	git add -u
 	git commit -m "$(TODAY) release candidate"


### PR DESCRIPTION
The `make candidate` task uses the `gh` CLI to create a PR for a release candidate.

In order to use this, the token for the CLI requires permissions for: admin:org, repo, workflows

Test PR created using this workflow: https://github.com/obi-ontology/obi/pull/1268