### PR TITLE
Add material supplier, fix organization roles

### DIFF
--- a/src/ontology/modules/organizations.owl
+++ b/src/ontology/modules/organizations.owl
@@ -67,40 +67,11 @@
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
-    // Object Properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/RO_0000087 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000087"/>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
     // Classes
     //
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000014 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000014"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000018 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000018"/>
     
 
 
@@ -110,9 +81,21 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/OBI_0000571 -->
+    <!-- http://purl.obolibrary.org/obo/OBI_0000450 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000571"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000450"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000835 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000835"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0002989 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002989"/>
     
 
 
@@ -130,19 +113,8 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000462 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000462">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000018"/>
-            </owl:Restriction>
-        </rdf:type>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0002989"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Affymetrix</obo:IAO_0000111>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Affymetrix supplied microarray</obo:IAO_0000112>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organization which supplies technology, tools and protocols for use in high throughput applications</obo:IAO_0000115>
@@ -154,13 +126,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000752 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000752">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thermo</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thermo</rdfs:label>
@@ -171,13 +137,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000753 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000753">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Waters</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Waters</rdfs:label>
@@ -188,13 +148,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000754 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000754">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BIO-RAD</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BIO-RAD</rdfs:label>
@@ -205,13 +159,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000756 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000756">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ambion</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ambion</rdfs:label>
@@ -222,13 +170,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000757 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000757">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Helicos</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Helicos</rdfs:label>
@@ -239,13 +181,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000758 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000758">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Roche</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Roche</rdfs:label>
@@ -256,13 +192,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000759 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000759">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Illumina</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Illumina</rdfs:label>
@@ -273,13 +203,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000765 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000765">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Agilent</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Agilent</rdfs:label>
@@ -290,13 +214,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000769 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000769">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Li-Cor</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Li-Cor</rdfs:label>
@@ -307,13 +225,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000770 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000770">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bruker Corporation</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bruker Corporation</rdfs:label>
@@ -324,13 +236,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000776 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000776">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Applied Biosystems</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Applied Biosystems</rdfs:label>
@@ -341,13 +247,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000779 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000779">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bruker Daltonics</obo:IAO_0000111>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Philippe Rocca-Serra</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bruker Daltonics</rdfs:label>
@@ -358,13 +258,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000829 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000829">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sysmex Corporation, Kobe, Japan</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WEB:http://www.sysmex.com/@2009/08/06</obo:IAO_0000119>
@@ -376,13 +270,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000901 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0000901">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000014"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000450"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">U.S. Food and Drug Administration</obo:IAO_0000111>
         <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FDA</obo:IAO_0000118>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">U.S. Food and Drug Administration</rdfs:label>
@@ -393,13 +281,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001213 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001213">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eBioscience</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -412,13 +294,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001224 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001224">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytopeia</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -431,13 +307,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001287 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001287">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Exalpha Biological</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -450,13 +320,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001312 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001312">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apogee Flow Systems</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -469,13 +333,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001320 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001320">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Exbio Antibodies</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -488,13 +346,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001321 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001321">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Becton Dickinson (BD Biosciences)</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -507,13 +359,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001338 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001338">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dako Cytomation</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -526,13 +372,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001340 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001340">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Millipore</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -545,13 +385,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001347 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001347">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Antigenix</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -564,13 +398,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001355 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001355">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Partec</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -583,13 +411,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001372 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001372">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Beckman Coulter</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -602,13 +424,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001375 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001375">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Advanced Instruments Inc. (AI Companies)</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -621,13 +437,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001424 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001424">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Miltenyi Biotec</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -640,13 +450,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001428 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001428">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AES Chemunex</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -659,13 +463,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001431 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001431">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bentley Instruments</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -678,13 +476,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001434 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001434">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Invitrogen</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -697,13 +489,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001443 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001443">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luminex</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -716,13 +502,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001458 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001458">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CytoBuoy</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supplier of flow cytometry analyzers</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karin Breuer</obo:IAO_0000117>
@@ -735,13 +515,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001855 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001855">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nimblegen</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organization that focuses on manufacturing target enrichment probe pools for DNA sequencing.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Person: Jie Zheng</obo:IAO_0000117>
@@ -753,13 +527,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001856 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001856">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pacific Biosciences</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organization that supplies tools for studying the synthesis and regulation of DNA, RNA and protein. It developed a powerful technology platform called single molecule real-time (SMRT) technology which enables real-time analysis of biomolecules with single molecule resolution.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Person: Jie Zheng</obo:IAO_0000117>
@@ -771,13 +539,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0001860 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0001860">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NanoString Technologies</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organization that supplies life science tools for translational research and molecular diagnostics based on a novel digital molecular barcoding technology. The NanoString platform can provide simple, multiplexed digital profiling of single molecules.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NanoString Technologies</rdfs:label>
@@ -801,13 +563,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0002755 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0002755">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oxford Nanopore Technologies</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organization that is developing and selling nanopore sequencing products and is based in the UK.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">James A. Overton</obo:IAO_0000117>
@@ -820,13 +576,7 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0002903 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/OBI_0002903">
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <rdf:type>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000571"/>
-            </owl:Restriction>
-        </rdf:type>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/OBI_0000835"/>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BioGents</obo:IAO_0000111>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organization that manufactures mosquito traps and other mosquito control products.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">John Judkins</obo:IAO_0000117>

--- a/src/ontology/obi-edit.owl
+++ b/src/ontology/obi-edit.owl
@@ -20849,6 +20849,35 @@ b) that the amount of analyte/measurand detected is over some predetermined thre
     
 
 
+    <!-- http://purl.obolibrary.org/obo/OBI_0002989 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002989">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000245"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000018"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <obo:IAO_0000111>material supplier</obo:IAO_0000111>
+        <obo:IAO_0000115>A person or organization that provides material supplies to other people or organizations.</obo:IAO_0000115>
+        <obo:IAO_0000117>Rebecca Jackson</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/obi-ontology/obi/issues/1289</obo:IAO_0000233>
+        <rdfs:label>material supplier</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/OBI_0005246 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0005246">

--- a/src/ontology/templates/organizations.tsv
+++ b/src/ontology/templates/organizations.tsv
@@ -1,41 +1,41 @@
-Ontology ID	label	curation status	editor preferred term	alternative term	definition	definition source	example of usage	term editor	Type	has role
-ID	LABEL	AI has curation status	A editor preferred term	A alternative term SPLIT=|	A definition	A definition source SPLIT=|	A example of usage SPLIT=|	A term editor SPLIT=|	TYPE SPLIT=|	TI 'has role' some % SPLIT=|
-OBI:0000462	Affymetrix		Affymetrix		An organization which supplies technology, tools and protocols for use in high throughput applications		Affymetrix supplied microarray		organization	manufacturer role|material supplier role
-OBI:0000752	Thermo		Thermo					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000753	Waters		Waters					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000754	BIO-RAD		BIO-RAD					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000756	Ambion		Ambion					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000757	Helicos		Helicos					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000758	Roche		Roche					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000759	Illumina		Illumina					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000765	Agilent		Agilent					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000769	Li-Cor		Li-Cor					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000770	Bruker Corporation		Bruker Corporation					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000776	Applied Biosystems		Applied Biosystems					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000779	Bruker Daltonics		Bruker Daltonics					Philippe Rocca-Serra	organization	manufacturer role
-OBI:0000829	Sysmex Corporation, Kobe, Japan	metadata complete	Sysmex Corporation, Kobe, Japan			WEB:http://www.sysmex.com/@2009/08/06			organization	manufacturer role
-OBI:0000901	U.S. Food and Drug Administration		U.S. Food and Drug Administration	FDA					organization	regulator role
-OBI:0001213	eBioscience		eBioscience		A supplier of flow cytometry analyzers	WEB:http://www.ebioscience.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001224	Cytopeia		Cytopeia		A supplier of flow cytometry analyzers	WEB:http://www.cytopeia.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001287	Exalpha Biological		Exalpha Biological		A supplier of flow cytometry analyzers	WEB:http://www.exalpha.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001312	Apogee Flow Systems		Apogee Flow Systems		A supplier of flow cytometry analyzers	WEB:http://www.apogeeflow.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001320	Exbio Antibodies		Exbio Antibodies		A supplier of flow cytometry analyzers	WEB:http://www.exbio.cz/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001321	Becton Dickinson (BD Biosciences)		Becton Dickinson (BD Biosciences)		A supplier of flow cytometry analyzers	WEB:http://www.bdbiosciences.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001338	Dako Cytomation		Dako Cytomation		A supplier of flow cytometry analyzers	WEB:http://www.dakousa.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001340	Millipore		Millipore		A supplier of flow cytometry analyzers	WEB:http://www.guavatechnologies.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001347	Antigenix		Antigenix		A supplier of flow cytometry analyzers	WEB:http://www.antigenix.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001355	Partec		Partec		A supplier of flow cytometry analyzers	WEB:http://www.partec.de/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001372	Beckman Coulter		Beckman Coulter		A supplier of flow cytometry analyzers	WEB:http://www.beckmancoulter.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001375	Advanced Instruments Inc. (AI Companies)		Advanced Instruments Inc. (AI Companies)		A supplier of flow cytometry analyzers	WEB:http://www.aicompanies.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001424	Miltenyi Biotec		Miltenyi Biotec		A supplier of flow cytometry analyzers	WEB:http://www.miltenyibiotec.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001428	AES Chemunex		AES Chemunex		A supplier of flow cytometry analyzers	WEB:http://www.aeschemunex.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001431	Bentley Instruments		Bentley Instruments		A supplier of flow cytometry analyzers	WEB:http://bentleyinstruments.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001434	Invitrogen		Invitrogen		A supplier of flow cytometry analyzers	WEB:http://www.invitrogen.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001443	Luminex		Luminex		A supplier of flow cytometry analyzers	WEB:http://www.luminexcorp.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001458	CytoBuoy		CytoBuoy		A supplier of flow cytometry analyzers	WEB:http://www.cytobuoy.com/@2011/04/11		Karin Breuer	organization	manufacturer role
-OBI:0001855	Nimblegen		Nimblegen		An organization that focuses on manufacturing target enrichment probe pools for DNA sequencing.			Person: Jie Zheng	organization	manufacturer role
-OBI:0001856	Pacific Biosciences		Pacific Biosciences		An organization that supplies tools for studying the synthesis and regulation of DNA, RNA and protein. It developed a powerful technology platform called single molecule real-time (SMRT) technology which enables real-time analysis of biomolecules with single molecule resolution.			Person: Jie Zheng	organization	manufacturer role
-OBI:0001860	NanoString Technologies		NanoString Technologies		An organization that supplies life science tools for translational research and molecular diagnostics based on a novel digital molecular barcoding technology. The NanoString platform can provide simple, multiplexed digital profiling of single molecules.				organization	manufacturer role
-OBI:0002193	Thermo Fisher Scientific		Thermo Fisher Scientific		An organization that is an American multinational, biotechnology product development company, created in 2006 by the merger of Thermo Electron and Fisher Scientific.	https://en.wikipedia.org/wiki/Thermo_Fisher_Scientific		Chris Stoeckert, Helena Ellis	organization	
-OBI:0002755	Oxford Nanopore Technologies		Oxford Nanopore Technologies		An organization that is developing and selling nanopore sequencing products and is based in the UK.	https://en.wikipedia.org/wiki/Oxford_Nanopore_Technologies		James A. Overton	organization	manufacturer role
-OBI:0002903	BioGents		BioGents		An organization that manufactures mosquito traps and other mosquito control products.	WEB:https://eu.biogents.com/about-biogents/		John Judkins	organization	manufacturer role
+Ontology ID	label	curation status	editor preferred term	alternative term	definition	definition source	example of usage	term editor	Type
+ID	LABEL	AI has curation status	A editor preferred term	A alternative term SPLIT=|	A definition	A definition source SPLIT=|	A example of usage SPLIT=|	A term editor SPLIT=|	TYPE SPLIT=|
+OBI:0000462	Affymetrix		Affymetrix		An organization which supplies technology, tools and protocols for use in high throughput applications		Affymetrix supplied microarray		manufacturer|material supplier
+OBI:0000752	Thermo		Thermo					Philippe Rocca-Serra	manufacturer
+OBI:0000753	Waters		Waters					Philippe Rocca-Serra	manufacturer
+OBI:0000754	BIO-RAD		BIO-RAD					Philippe Rocca-Serra	manufacturer
+OBI:0000756	Ambion		Ambion					Philippe Rocca-Serra	manufacturer
+OBI:0000757	Helicos		Helicos					Philippe Rocca-Serra	manufacturer
+OBI:0000758	Roche		Roche					Philippe Rocca-Serra	manufacturer
+OBI:0000759	Illumina		Illumina					Philippe Rocca-Serra	manufacturer
+OBI:0000765	Agilent		Agilent					Philippe Rocca-Serra	manufacturer
+OBI:0000769	Li-Cor		Li-Cor					Philippe Rocca-Serra	manufacturer
+OBI:0000770	Bruker Corporation		Bruker Corporation					Philippe Rocca-Serra	manufacturer
+OBI:0000776	Applied Biosystems		Applied Biosystems					Philippe Rocca-Serra	manufacturer
+OBI:0000779	Bruker Daltonics		Bruker Daltonics					Philippe Rocca-Serra	manufacturer
+OBI:0000829	Sysmex Corporation, Kobe, Japan	metadata complete	Sysmex Corporation, Kobe, Japan			WEB:http://www.sysmex.com/@2009/08/06			manufacturer
+OBI:0000901	U.S. Food and Drug Administration		U.S. Food and Drug Administration	FDA					regulatory agency
+OBI:0001213	eBioscience		eBioscience		A supplier of flow cytometry analyzers	WEB:http://www.ebioscience.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001224	Cytopeia		Cytopeia		A supplier of flow cytometry analyzers	WEB:http://www.cytopeia.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001287	Exalpha Biological		Exalpha Biological		A supplier of flow cytometry analyzers	WEB:http://www.exalpha.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001312	Apogee Flow Systems		Apogee Flow Systems		A supplier of flow cytometry analyzers	WEB:http://www.apogeeflow.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001320	Exbio Antibodies		Exbio Antibodies		A supplier of flow cytometry analyzers	WEB:http://www.exbio.cz/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001321	Becton Dickinson (BD Biosciences)		Becton Dickinson (BD Biosciences)		A supplier of flow cytometry analyzers	WEB:http://www.bdbiosciences.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001338	Dako Cytomation		Dako Cytomation		A supplier of flow cytometry analyzers	WEB:http://www.dakousa.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001340	Millipore		Millipore		A supplier of flow cytometry analyzers	WEB:http://www.guavatechnologies.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001347	Antigenix		Antigenix		A supplier of flow cytometry analyzers	WEB:http://www.antigenix.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001355	Partec		Partec		A supplier of flow cytometry analyzers	WEB:http://www.partec.de/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001372	Beckman Coulter		Beckman Coulter		A supplier of flow cytometry analyzers	WEB:http://www.beckmancoulter.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001375	Advanced Instruments Inc. (AI Companies)		Advanced Instruments Inc. (AI Companies)		A supplier of flow cytometry analyzers	WEB:http://www.aicompanies.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001424	Miltenyi Biotec		Miltenyi Biotec		A supplier of flow cytometry analyzers	WEB:http://www.miltenyibiotec.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001428	AES Chemunex		AES Chemunex		A supplier of flow cytometry analyzers	WEB:http://www.aeschemunex.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001431	Bentley Instruments		Bentley Instruments		A supplier of flow cytometry analyzers	WEB:http://bentleyinstruments.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001434	Invitrogen		Invitrogen		A supplier of flow cytometry analyzers	WEB:http://www.invitrogen.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001443	Luminex		Luminex		A supplier of flow cytometry analyzers	WEB:http://www.luminexcorp.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001458	CytoBuoy		CytoBuoy		A supplier of flow cytometry analyzers	WEB:http://www.cytobuoy.com/@2011/04/11		Karin Breuer	manufacturer
+OBI:0001855	Nimblegen		Nimblegen		An organization that focuses on manufacturing target enrichment probe pools for DNA sequencing.			Person: Jie Zheng	manufacturer
+OBI:0001856	Pacific Biosciences		Pacific Biosciences		An organization that supplies tools for studying the synthesis and regulation of DNA, RNA and protein. It developed a powerful technology platform called single molecule real-time (SMRT) technology which enables real-time analysis of biomolecules with single molecule resolution.			Person: Jie Zheng	manufacturer
+OBI:0001860	NanoString Technologies		NanoString Technologies		An organization that supplies life science tools for translational research and molecular diagnostics based on a novel digital molecular barcoding technology. The NanoString platform can provide simple, multiplexed digital profiling of single molecules.				manufacturer
+OBI:0002193	Thermo Fisher Scientific		Thermo Fisher Scientific		An organization that is an American multinational, biotechnology product development company, created in 2006 by the merger of Thermo Electron and Fisher Scientific.	https://en.wikipedia.org/wiki/Thermo_Fisher_Scientific		Chris Stoeckert, Helena Ellis	organization
+OBI:0002755	Oxford Nanopore Technologies		Oxford Nanopore Technologies		An organization that is developing and selling nanopore sequencing products and is based in the UK.	https://en.wikipedia.org/wiki/Oxford_Nanopore_Technologies		James A. Overton	manufacturer
+OBI:0002903	BioGents		BioGents		An organization that manufactures mosquito traps and other mosquito control products.	WEB:https://eu.biogents.com/about-biogents/		John Judkins	manufacturer


### PR DESCRIPTION
Resolves #1289

This adds a new class (OBI:0002989) 'material supplier':
> A person or organization that provides material supplies to other people or organizations.

And replaces all `has role` axioms on organization individuals with the corresponding class as the type.