### PR TITLE
Add locate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ Our ontology terms come in three groups. Depending on what type of term you want
 
 See below for a full list of files, build instructions, and instructions on using Git and GitHub for OBI.
 
+### Finding Terms
+
+To find where a term lives, you can use [`src/scripts/locate.py`](src/scripts/locate.py). This requires you first to build a database from the merged OBI file:
+```
+make build/obi_merged.db
+```
+
+Then you can run the script to find terms by ID or label by passing them as a space-separated list, for example:
+```
+src/scripts/locate.py OBI:0000070 CHMO:0000087 GO:0000785
+```
+
+Labels should be enclosed in double quotes:
+```
+src/scripts/locate.py "assay" "fluorescence microscopy" "chromatin"
+```
+
 
 # Files
 

--- a/src/scripts/locate.py
+++ b/src/scripts/locate.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+#
+# Locate terms by ID or label.
+
+import csv
+import os
+import re
+import sqlite3
+import sys
+
+from argparse import ArgumentParser
+
+OBI_DB = "build/obi_merged.db"
+TEMPLATES_DIR = "src/ontology/templates"
+IMPORTS_DIR = "src/ontology/OntoFox_inputs"
+
+
+def locate_term(cur, term_id):
+    for f in os.listdir(TEMPLATES_DIR):
+        fname = os.path.join(TEMPLATES_DIR, f)
+        with open(fname, "r") as fr:
+            reader = csv.DictReader(fr, delimiter="\t")
+            i = 1
+            for row in reader:
+                i += 1
+                if term_id == row.get("Ontology ID"):
+                    return fname + ":" + str(i)
+    for f in os.listdir(IMPORTS_DIR):
+        fname = os.path.join(IMPORTS_DIR, f)
+        term_iri = "http://purl.obolibrary.org/obo/" + term_id.replace(":", "_")
+        i = 0
+        with open(fname, "r") as fr:
+            for line in fr.readlines():
+                i += 1
+                if not line:
+                    continue
+                if line.split(" ")[0].strip() == term_iri:
+                    return fname + ":" + str(i)
+    cur.execute("SELECT * FROM statements WHERE stanza = ?", (term_id,))
+    res = cur.fetchone()
+    if res:
+        return "src/ontology/obi-edit.owl"
+    return None
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("terms", help="One or more space-separated IDs or labels", nargs="+")
+    args = parser.parse_args()
+
+    if not os.path.exists(OBI_DB):
+        print("ERROR: database does not exist! Run 'make build/obi_merged.db' and try again.")
+        sys.exit(1)
+
+    locs = []
+    with sqlite3.connect(OBI_DB) as conn:
+        cur = conn.cursor()
+        for term in args.terms:
+            # Check if term is a not a CURIE, we need to find the ID
+            if not re.match(r"^[A-Z]+:[0-9]+$", term):
+                cur.execute(
+                    "SELECT stanza FROM statements WHERE predicate = 'rdfs:label' AND value = ?",
+                    (term,)
+                )
+                res = cur.fetchone()
+                if not res:
+                    locs.append([term, "NOT FOUND"])
+                    continue
+                term_id = res[0]
+            else:
+                term_id = term
+            loc = locate_term(cur, term_id)
+            if loc:
+                locs.append([term, loc])
+            else:
+                locs.append([term, "NOT FOUND"])
+
+    for term_loc in locs:
+        print(f"{term_loc[0]}\t{term_loc[1]}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/scripts/locate.py
+++ b/src/scripts/locate.py
@@ -17,29 +17,50 @@ IMPORTS_DIR = "src/ontology/OntoFox_inputs"
 
 def locate_term(cur, term_id):
     for f in os.listdir(TEMPLATES_DIR):
+        if not f.endswith(".tsv"):
+            continue
         fname = os.path.join(TEMPLATES_DIR, f)
-        with open(fname, "r") as fr:
-            reader = csv.DictReader(fr, delimiter="\t")
-            i = 1
-            for row in reader:
-                i += 1
-                if term_id == row.get("Ontology ID"):
-                    return fname + ":" + str(i)
+        try:
+            with open(fname, "r") as fr:
+                reader = csv.DictReader(fr, delimiter="\t")
+                i = 1
+                for row in reader:
+                    i += 1
+                    if term_id == row.get("Ontology ID"):
+                        return fname + ":" + str(i)
+        except Exception as e:
+            raise Exception(f"Failed to read {fname}", e)
     for f in os.listdir(IMPORTS_DIR):
+        if not f.endswith(".txt"):
+            continue
         fname = os.path.join(IMPORTS_DIR, f)
         term_iri = "http://purl.obolibrary.org/obo/" + term_id.replace(":", "_")
         i = 0
-        with open(fname, "r") as fr:
-            for line in fr.readlines():
-                i += 1
-                if not line:
-                    continue
-                if line.split(" ")[0].strip() == term_iri:
-                    return fname + ":" + str(i)
+        try:
+            with open(fname, "r") as fr:
+                for line in fr.readlines():
+                    i += 1
+                    if not line:
+                        continue
+                    if line.split(" ")[0].strip() == term_iri:
+                        return fname + ":" + str(i)
+        except Exception as e:
+            raise Exception(f"Failed to read {fname}", e)
     cur.execute("SELECT * FROM statements WHERE stanza = ?", (term_id,))
     res = cur.fetchone()
     if res:
-        return "src/ontology/obi-edit.owl"
+        fname = "src/ontology/obi-edit.owl"
+        term_iri = "http://purl.obolibrary.org/obo/" + term_id.replace(":", "_")
+        try:
+            with open(fname, "r") as fr:
+                for line in fr.readlines():
+                    i += 1
+                    if not line:
+                        continue
+                    if "rdf:about=" in line and term_iri in line:
+                        return fname + ":" + str(i)
+        except Exception as e:
+            raise Exception(f"Failed to read {fname}", e)
     return None
 
 

--- a/src/scripts/prefixes.sql
+++ b/src/scripts/prefixes.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS prefix (
+  prefix TEXT PRIMARY KEY,
+  base TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO prefix VALUES
+("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+("rdfs", "http://www.w3.org/2000/01/rdf-schema#"),
+("xsd", "http://www.w3.org/2001/XMLSchema#"),
+("owl", "http://www.w3.org/2002/07/owl#"),
+("oio", "http://www.geneontology.org/formats/oboInOwl#"),
+("dce", "http://purl.org/dc/elements/1.1/"),
+("dct", "http://purl.org/dc/terms/"),
+("foaf", "http://xmlns.com/foaf/0.1/"),
+("obo", "http://purl.obolibrary.org/obo/"),
+
+("BFO", "http://purl.obolibrary.org/obo/BFO_"),
+("CHMO", "http://purl.obolibrary.org/obo/CHMO_"),
+("CL", "http://purl.obolibrary.org/obo/CL_"),
+("CLO", "http://purl.obolibrary.org/obo/CLO_"),
+("CHEBI", "http://purl.obolibrary.org/obo/CHEBI_"),
+("ENVO", "http://purl.obolibrary.org/obo/ENVO_"),
+("GO", "http://purl.obolibrary.org/obo/GO_"),
+("HP", "http://purl.obolibrary.org/obo/HP_"),
+("IAO", "http://purl.obolibrary.org/obo/IAO_"),
+("IDO", "http://purl.obolibrary.org/obo/IDO_"),
+("NCBITaxon", "http://purl.obolibrary.org/obo/NCBITaxon_"),
+("OBI", "http://purl.obolibrary.org/obo/OBI_"),
+("OGMS", "http://purl.obolibrary.org/obo/OGMS_"),
+("OMIABIS", "http://purl.obolibrary.org/obo/OMIABIS_"),
+("OMRSE", "http://purl.obolibrary.org/obo/OMRSE_"),
+("PATO", "http://purl.obolibrary.org/obo/PATO_"),
+("PR", "http://purl.obolibrary.org/obo/PR_"),
+("SO", "http://purl.obolibrary.org/obo/SO_"),
+("UBERON", "http://purl.obolibrary.org/obo/UBERON_"),
+("UO", "http://purl.obolibrary.org/obo/UO_"),
+("VO", "http://purl.obolibrary.org/obo/VO_");


### PR DESCRIPTION
Resolves #1339 - added to README:

### Finding Terms

To find where a term lives, you can use [`src/scripts/locate.py`](src/scripts/locate.py). This requires you first to build a database from the merged OBI file:
```
make build/obi_merged.db
```

Then you can run the script to find terms by ID or label by passing them as a space-separated list, for example:
```
src/scripts/locate.py OBI:0000070 CHMO:0000087 GO:0000785
```

Labels should be enclosed in double quotes:
```
src/scripts/locate.py "assay" "fluorescence microscopy" "chromatin"