### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/obi-test.yml
+++ b/.github/workflows/obi-test.yml
@@ -1,0 +1,22 @@
+# Workflow for OBI Testing
+
+name: OBI Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  doid_ci:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run test
+        run: |
+          make test

--- a/.github/workflows/obi-test.yml
+++ b/.github/workflows/obi-test.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  doid_ci:
+  obi_test:
 
     runs-on: ubuntu-latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: java
-script: make test


### PR DESCRIPTION
We've run out of Travis credits, so the tests are no longer running.

This PR removes the Travis file and adds an Actions workflow that runs the same test any time there is a push or PR to `master`.

Note: the first workflow failed because I manually canceled it.