### PR TITLE
Add workflow to make OBI Excel sheet for editing templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 catalog-v001.xml
 junk/
+*.xlsx

--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,21 @@ MODULE_NAMES := assays\
  sequence-analysis\
  value-specifications
 MODULE_FILES := $(foreach x,$(MODULE_NAMES),src/ontology/modules/$(x).owl)
+TEMPLATE_FILES := $(foreach x,$(MODULE_NAMES),src/ontology/templates/$(x).tsv)
 
 .PHONY: modules
 modules: $(MODULE_FILES)
+
+obi.xlsx: src/scripts/tsv2xlsx.py $(TEMPLATE_FILES)
+	python3 $< $@ $(wordlist 2,100,$^)
+
+.PHONY: update-tsv
+update-tsv: update-tsv-files sort
+
+.PHONY: update-tsv-files
+update-tsv-files:
+	$(foreach x,$(MODULE_NAMES),python3 src/scripts/xlsx2tsv.py obi.xlsx $(x) src/ontology/templates/$(x).tsv;)
+
 
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ Our ontology terms come in three groups. Depending on what type of term you want
 
 See below for a full list of files, build instructions, and instructions on using Git and GitHub for OBI.
 
+### Editing Templates in Excel
+
+If you wish to edit a template or templates in Excel, rather than copy & pasting the template, we ask that you follow this workflow to preserve quoting. Going back and forth with Excel can cause some unintentional changes to double quotes within templates.
+
+First, install the python requirements:
+```
+python3 -m pip install -r requirements.txt
+```
+
+Then, make the Excel sheet:
+```
+make obi.xlsx
+```
+
+Edit the sheet, save it, and finally, run the following to update the TSV versions of the templates:
+```
+make update-tsv
+```
+
 ### Finding Terms
 
 To find where a term lives, you can use [`src/scripts/locate.py`](src/scripts/locate.py). This requires you first to build a database from the merged OBI file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+openpyxl

--- a/src/scripts/tsv2xlsx.py
+++ b/src/scripts/tsv2xlsx.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import os
+
+from openpyxl import Workbook
+
+parser = argparse.ArgumentParser(description="Merge TSV files into Excel")
+parser.add_argument("output", type=str, help="Excel file to create")
+parser.add_argument("inputs", type=str, nargs="+", help="TSV files to include")
+args = parser.parse_args()
+
+wb = Workbook()
+wb.remove(wb.active)
+
+for path in args.inputs:
+    title, extension = os.path.splitext(os.path.basename(path))
+    ws = wb.create_sheet(title)
+    with open(path, "r") as tsvin:
+        tsv = csv.reader(tsvin, delimiter="\t", quoting=csv.QUOTE_NONE, escapechar='"')
+        for row in tsv:
+            ws.append(row[:])
+
+wb.save(args.output)

--- a/src/scripts/xlsx2tsv.py
+++ b/src/scripts/xlsx2tsv.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import os
+
+from openpyxl import load_workbook
+
+parser = argparse.ArgumentParser(description="Read TSV from Excel")
+parser.add_argument("input", type=str, help="Excel file to read")
+parser.add_argument("sheet", type=str, help="Sheet name to read")
+parser.add_argument("output", type=str, help="TSV file to output")
+args = parser.parse_args()
+
+wb = load_workbook(args.input)
+ws = wb[args.sheet]
+
+rows = []
+for row in ws:
+    values = []
+    for cell in row:
+        if cell.value is None:
+            values.append("")
+        else:
+            values.append(cell.value)
+    if row:
+      rows.append(values)
+
+with open(args.output, "w") as f:
+  writer = csv.writer(f, delimiter="\t", lineterminator="\n", quoting=csv.QUOTE_NONE, escapechar='"')
+  writer.writerows(rows)


### PR DESCRIPTION
This workflow allows editors to create an Excel spreadsheet from our templates, edit it, and convert the spreadsheet back to TSVs to build the modules:
1. Run `make obi.xlsx`
2. Edit `obi.xlsx`
3. Run `make update-tsv`
4. Run `make modules`

Note that this requires `openpyxl` for the Python scripts. Install with:
```
python3 -m pip install -r requirements.txt
```

... or:
```
python3 -m pip install openpyxl
```

(Since we just have one requirement, maybe we don't need a requirements file? I don't know.)