### PR TITLE
Rework base file generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,8 +190,9 @@ obi.owl: build/obi_merged.owl
 views/obi-base.owl: src/ontology/obi-edit.owl | build/robot.jar
 	$(ROBOT) remove --input $< \
 	--select imports \
-	merge $(foreach M,$(MODULE_FILES), --input $(M)) \
-	query --update src/sparql/fix-iao.rq \
+	--output build/obi-edit-bare.owl
+	$(ROBOT) merge --input build/obi-edit-bare.owl \
+	$(foreach M,$(MODULE_FILES), --input $(M)) \
 	annotate \
 	--ontology-iri "$(OBO)/obi/obi-base.owl" \
 	--version-iri "$(OBO)/obi/$(TODAY)/obi-base.owl" \


### PR DESCRIPTION
Hector and I have been eliminating ROBOT report errors from OBI. By running report on the OBI base file we focus on just errors in OBI, ignoring any upstream errors.

One error we found was duplicate definitions for has_specified_input/specified_input_of and has_specified_output/specified_output_of. Strangely, these were already fixed in OBI by #1406, but are being re-imported from IAO. #1406 includes a SPARQL UPDATE query to fix that problem for `obi.owl`. In #1541 I added that SPARQL query to the task to generate `obi-base.owl`.

Now I realize that my change in #1541 shouldn't have been necessary: The generation of `obi-base.owl` should not include anything from IAO, not even these re-imports of OBI terms. So I looked at the Make task again, and realized that the `remove --select imports` step will (1) load `obi-edit.owl`, (2) remove the import statements, then (3) pass the **loaded** OWLOntology (without import **statements** but still including the loaded imports) to the next step. So the following steps include the re-imports from IAO, and possibly other things we don't want.

In this PR I break the Make task into two steps. First I `remove --select imports` and then save to a temporary file. Then I load the temporary file and continue the process. Since the temporary file does not contain any import statements, it does not re-import from IAO, and the SPARQL query fix is not required.

Another result is that this does not pass the OBI base file through Apache Jena, which means no changes to the RDF plain literals. This may or may not be desirable. But overall I think this is a better way to generate an OBI basefile.