### PR TITLE
changes to "material to be added role"

### DIFF
--- a/src/ontology/obi-edit.owl
+++ b/src/ontology/obi-edit.owl
@@ -1282,21 +1282,6 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
     
 
 
-    <!-- http://purl.obolibrary.org/obo/OBI_0003384 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0003384">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0600014"/>
-        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">synaptosome preparation process</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">A material component separation process where a synaptic terminal is isolated from a neuron by mild homogenization of nervous tissue under isotonic conditions and subsequent fractionation using differential and density gradient centrifugation.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Michelle Giglio</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">Suvarna Nadendla</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">url:https://en.wikipedia.org/wiki/Synaptosome</obo:IAO_0000119>
-        <obo:IAO_0000234>CFDE-GlyGen</obo:IAO_0000234>
-        <rdfs:label xml:lang="en">synaptosome preparation process</rdfs:label>
-    </owl:Class>
-    
-    
-    
     <!-- http://purl.obolibrary.org/obo/OBI_0003385 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0003385">
@@ -5720,7 +5705,7 @@ need to add mobile phase as role</obo:IAO_0000116>
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">material to be added role</obo:IAO_0000111>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drug added to a buffer contained in a tube; substance injected into an animal;</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
-        <obo:IAO_0000115 xml:lang="en">material to be added role is a protocol participant role realized by a material which is added into a material bearing the target of material addition role in a material addition process</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A role of a material entity that is realized in an &quot;adding a material entity into a target&quot; process where the bearer of the role is added into another material entity (the target).</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Role Branch</obo:IAO_0000117>
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBI</obo:IAO_0000119>
         <obo:IAO_0000232 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9 March 09 from discussion with PA branch</obo:IAO_0000232>
@@ -7019,7 +7004,7 @@ that has_part some material entity is a material entity. If we add as equivalent
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">target of material addition role</obo:IAO_0000111>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">peritoneum of an animal receiving an interperitoneal injection; solution in a tube receiving additional material; location of absorbed material following a dermal application.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">target of material addition role is a role realized by an entity into which a material is added in a material addition process</obo:IAO_0000115>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A role of a material entity that is realized in an &quot;adding a material entity into a target&quot; process where the bearer of the role (the target) receives the addition of another material entity.</obo:IAO_0000115>
         <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">From Branch discussion with BP, AR, MC -- there is a need for the recipient to interact with the administered material.  for example, a tooth receiving a filling was not considered to be a target role.</obo:IAO_0000116>
         <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GROUP:  Role Branch</obo:IAO_0000117>
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OBI</obo:IAO_0000119>
@@ -22063,7 +22048,22 @@ b) that the amount of analyte/measurand detected is over some predetermined thre
     
 
 
-   <!-- http://purl.obolibrary.org/obo/OBI_0003413 -->
+    <!-- http://purl.obolibrary.org/obo/OBI_0003384 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0003384">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0600014"/>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">synaptosome preparation process</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">A material component separation process where a synaptic terminal is isolated from a neuron by mild homogenization of nervous tissue under isotonic conditions and subsequent fractionation using differential and density gradient centrifugation.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Michelle Giglio</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Suvarna Nadendla</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">url:https://en.wikipedia.org/wiki/Synaptosome</obo:IAO_0000119>
+        <obo:IAO_0000234>CFDE-GlyGen</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">synaptosome preparation process</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0003413 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0003413">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0600007"/>
@@ -31521,7 +31521,7 @@ MHB 3-5-13: Need to review axiom on this class in light of clarification that it
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">material to be added</obo:IAO_0000111>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mixture of peptides that is being added into a cell culture.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a material that is added to another one in a material combination process</obo:IAO_0000115>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A material entity that is added to another maerial entity in an “adding a material entity into a target” process.</obo:IAO_0000115>
         <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">10/26/09: This defined class is used as a &apos;macro expression&apos; to reduce the  size of the IEDB export</obo:IAO_0000116>
         <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2010/02/24  Alan Ruttenberg: I think this might generate confusion as the common use of the term would consider something to be a specimen during the realization of the role, not only if it bears it. However having this class as a probe, or for display, or as a macro might be useful. Ideally we would mark or segregate such classes</obo:IAO_0000116>
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IEDB</obo:IAO_0000119>
@@ -31543,7 +31543,7 @@ MHB 3-5-13: Need to review axiom on this class in light of clarification that it
         <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">target of material addition</obo:IAO_0000111>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cell culture into which a mixture of peptides is being added.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A material entity into which another is being added in a material combinatino process</obo:IAO_0000115>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A material entity that receives the addition of another material entity in an “adding a material entity into a target” process.</obo:IAO_0000115>
         <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">10/26/09: This defined class is used as a &apos;macro&apos; to reduce the size of the IEDB export.</obo:IAO_0000116>
         <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IEDB</obo:IAO_0000119>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">target of material addition</rdfs:label>


### PR DESCRIPTION
This PR addresses the issues to "material to be added role" and related terms discussed in OBI PR [#1625](https://github.com/obi-ontology/obi/pull/1625) and IDO issue [#10](https://github.com/infectious-disease-ontology/infectious-disease-ontology/issues/10). 
 
It updates the textual definitions of "material to be added role," “target of material addition role,”  “material to be added,” and “target of material addition”.
 
@sebastianduesing, can you review these definition changes? Thanks.