### PR TITLE
Second round of `robot convert` with new OWLAPI

### DIFF
--- a/src/ontology/OntoFox_outputs/CLO_imports.owl
+++ b/src/ontology/OntoFox_outputs/CLO_imports.owl
@@ -55,19 +55,19 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CLO_0000001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0001866"/>
+        <obo:IAO_0000111>cell line cell</obo:IAO_0000111>
         <obo:IAO_0000111 xml:lang="en">cell line cell</obo:IAO_0000111>
         <obo:IAO_0000111 xml:lang="zh">细胞系细胞</obo:IAO_0000111>
-        <obo:IAO_0000111>cell line cell</obo:IAO_0000111>
         <obo:IAO_0000115 xml:lang="en">A cultured cell that is part of a cell line - a stable and homogeneous population of cells with a common biological origin and propagation history in culture</obo:IAO_0000115>
-        <obo:IAO_0000115>一个培养细胞，它是一个细胞株（一个稳定的，同质的细胞群，具有共同的生物学起源和增殖史）的一部分</obo:IAO_0000115>
         <obo:IAO_0000115>A cultured cell that is part of a cell line - a stable and homogeneous population of cells with a common biological origin and propagation history in culture
 </obo:IAO_0000115>
+        <obo:IAO_0000115>一个培养细胞，它是一个细胞株（一个稳定的，同质的细胞群，具有共同的生物学起源和增殖史）的一部分</obo:IAO_0000115>
         <obo:IAO_0000115>一个培养细胞，它是一个细胞株（一个稳定的，同质的细胞群，具有共同的生物学起源和增殖史）的一部分
 </obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
+        <rdfs:label>cell line cell</rdfs:label>
         <rdfs:label xml:lang="en">cell line cell</rdfs:label>
         <rdfs:label xml:lang="zh">细胞系细胞</rdfs:label>
-        <rdfs:label>cell line cell</rdfs:label>
     </owl:Class>
     
 
@@ -76,15 +76,15 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CLO_0000018">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CLO_0000001"/>
+        <obo:IAO_0000111>mortal cell line cell</obo:IAO_0000111>
         <obo:IAO_0000111 xml:lang="en">mortal cell line cell</obo:IAO_0000111>
         <obo:IAO_0000111 xml:lang="zh">非永生细胞系细胞</obo:IAO_0000111>
-        <obo:IAO_0000111>mortal cell line cell</obo:IAO_0000111>
         <obo:IAO_0000115>A cell line cell that is capable of replicating a limited number of times in culture before undergoing senescence.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">A cell line cell that is capable of replicating a limited number of times in culture before undergoing senescence.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
+        <rdfs:label>mortal cell line cell</rdfs:label>
         <rdfs:label xml:lang="en">mortal cell line cell</rdfs:label>
         <rdfs:label xml:lang="zh">非永生细胞系细胞</rdfs:label>
-        <rdfs:label>mortal cell line cell</rdfs:label>
     </owl:Class>
     
 
@@ -93,16 +93,16 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CLO_0000019">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CLO_0000001"/>
+        <obo:IAO_0000111>immortal cell line cell</obo:IAO_0000111>
         <obo:IAO_0000111 xml:lang="en">immortal cell line cell</obo:IAO_0000111>
         <obo:IAO_0000111 xml:lang="zh">永生细胞系细胞</obo:IAO_0000111>
-        <obo:IAO_0000111>immortal cell line cell</obo:IAO_0000111>
         <obo:IAO_0000115>A cell line cell that is expected to be capable of an unlimited number of divisions, and is thus able to support indefinite propagation in vitro as part of an immortal cell line.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">A cell line cell that is expected to be capable of an unlimited number of divisions, and is thus able to support indefinite propagation in vitro as part of an immortal cell line.</obo:IAO_0000115>
         <obo:IAO_0000115>预期能够进行无限次分裂的细胞系细胞，作为永生细胞系一部分，能够支持体外无限增殖。</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
+        <rdfs:label>immortal cell line cell</rdfs:label>
         <rdfs:label xml:lang="en">immortal cell line cell</rdfs:label>
         <rdfs:label xml:lang="zh">永生细胞系细胞</rdfs:label>
-        <rdfs:label>immortal cell line cell</rdfs:label>
     </owl:Class>
     
 
@@ -114,10 +114,10 @@
         <obo:IAO_0000111 xml:lang="en">cell line</obo:IAO_0000111>
         <obo:IAO_0000111 xml:lang="zh">细胞系</obo:IAO_0000111>
         <obo:IAO_0000115 xml:lang="en">A cultured cell population that represents a genetically stable and homogenous population of cultured cells that shares a common propagation history (i.e. has been successively passaged together in culture). </obo:IAO_0000115>
+        <obo:IAO_0000115>A cultured cell population that represents a genetically stable and homogenous population of cultured cells that shares a common propagation history (i.e. has been successively passaged together in culture).  
+</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="zh">一个培养细胞群体，其代表具有共同增殖历史（即已经在培养中一起连续传代）的遗传稳定且同质的培养细胞群体。</obo:IAO_0000115>
         <obo:IAO_0000115>培养的细胞群体代表具有共同繁殖历史（即已经在培养中一起连续传代）的遗传稳定且同质的培养细胞群体。 
-</obo:IAO_0000115>
-        <obo:IAO_0000115>A cultured cell population that represents a genetically stable and homogenous population of cultured cells that shares a common propagation history (i.e. has been successively passaged together in culture).  
 </obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
         <rdfs:label xml:lang="en">cell line</rdfs:label>

--- a/src/ontology/OntoFox_outputs/IDO_imports.owl
+++ b/src/ontology/OntoFox_outputs/IDO_imports.owl
@@ -35,13 +35,13 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
-        <obo:IAO_0000111 xml:lang="en">definition</obo:IAO_0000111>
         <obo:IAO_0000111>definition</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">definition</obo:IAO_0000111>
         <obo:IAO_0000111>textual definition</obo:IAO_0000111>
         <obo:IAO_0000115 xml:lang="en">The official OBI definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">definition</rdfs:label>
         <rdfs:label>definition</rdfs:label>
+        <rdfs:label xml:lang="en">definition</rdfs:label>
         <rdfs:label>textual definition</rdfs:label>
     </owl:AnnotationProperty>
     

--- a/src/ontology/OntoFox_outputs/OMIABIS_imports.owl
+++ b/src/ontology/OntoFox_outputs/OMIABIS_imports.owl
@@ -39,13 +39,13 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
-        <obo:IAO_0000111 xml:lang="en">definition</obo:IAO_0000111>
         <obo:IAO_0000111>definition</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">definition</obo:IAO_0000111>
         <obo:IAO_0000111>textual definition</obo:IAO_0000111>
         <obo:IAO_0000115 xml:lang="en">The official OBI definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">definition</rdfs:label>
         <rdfs:label>definition</rdfs:label>
+        <rdfs:label xml:lang="en">definition</rdfs:label>
         <rdfs:label>textual definition</rdfs:label>
     </owl:AnnotationProperty>
     

--- a/src/ontology/OntoFox_outputs/VO_imports.owl
+++ b/src/ontology/OntoFox_outputs/VO_imports.owl
@@ -43,14 +43,14 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <obo:IAO_0000111>definition</obo:IAO_0000111>
         <obo:IAO_0000111 xml:lang="en">definition</obo:IAO_0000111>
         <obo:IAO_0000111>textual definition</obo:IAO_0000111>
-        <obo:IAO_0000111>definition</obo:IAO_0000111>
         <obo:IAO_0000115 xml:lang="en">The official OBI definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
+        <rdfs:label>definition</rdfs:label>
         <rdfs:label xml:lang="en">definition</rdfs:label>
         <rdfs:label>textual definition</rdfs:label>
-        <rdfs:label>definition</rdfs:label>
     </owl:AnnotationProperty>
     
 

--- a/src/ontology/obi-edit.owl
+++ b/src/ontology/obi-edit.owl
@@ -989,8 +989,8 @@ level of radioactivity is_proxy_for level of toxicity</obo:IAO_0000112>
         <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteProperty"/>
         <obo:IAO_0000111>has specified input information</obo:IAO_0000111>
         <obo:IAO_0000115 xml:lang="en">A relation between a process and a participant in that process, that consumes a data set . The process is the realization of a concretization of a directive information entity (objective specification or plan specification). In general, not all data present at the beginning of the process are specified_data.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
         <obo:IAO_0000117>PERSON: Frank Gibson</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
         <obo:IAO_0000118>consumes data</obo:IAO_0000118>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
         <rdfs:label xml:lang="en">obsoleted_has_specified_input_information</rdfs:label>
@@ -1514,8 +1514,8 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
 
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0002815">
         <obo:IAO_0000112 xml:lang="en">12th arrondissement of Paris</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">I feel sick to my stomach every Tuesday</obo:IAO_0000112>
         <obo:IAO_0000112>20g</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">I feel sick to my stomach every Tuesday</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">&apos;has representation&apos; is a data property that attaches between an information content entity and a value that contains linguistically or computationally coded text.</obo:IAO_0000115>
         <obo:IAO_0000116 xml:lang="en">Further processing may enable the value to be represented in a component data structure such as an OBI value specification.</obo:IAO_0000116>
@@ -3215,8 +3215,8 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
 objectives is a planned process.</obo:IAO_0000116>
         <obo:IAO_0000117>Bjoern Peters</obo:IAO_0000117>
         <obo:IAO_0000119>branch derived</obo:IAO_0000119>
-        <obo:IAO_0000232 xml:lang="en">This class merges the previously separated objective driven process and planned process, as they the separation proved hard to maintain. (1/22/09, branch call)</obo:IAO_0000232>
         <obo:IAO_0000232>6/11/9: Edited at workshop. Used to include: is initiated by an agent</obo:IAO_0000232>
+        <obo:IAO_0000232 xml:lang="en">This class merges the previously separated objective driven process and planned process, as they the separation proved hard to maintain. (1/22/09, branch call)</obo:IAO_0000232>
         <rdfs:label xml:lang="en">planned process</rdfs:label>
     </owl:Class>
     
@@ -3379,8 +3379,8 @@ objectives is a planned process.</obo:IAO_0000116>
         <obo:IAO_0000112>haemotoxylin is a general purpose nuclear stain extracted from the wood of the logwood tree WEB: http://en.wikipedia.org/wiki/Haematoxylin</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
         <obo:IAO_0000115>A dye role that is realized when the stain is used to colour cells and or cellular components for the purposes of visualization</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person:Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000117>Person:Helen Parkinson</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Person:Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000118>cytological stain</obo:IAO_0000118>
         <rdfs:label xml:lang="en">cytological stain role</rdfs:label>
     </owl:Class>
@@ -3703,9 +3703,9 @@ objectives is a planned process.</obo:IAO_0000116>
         <obo:IAO_0000115 xml:lang="en">a planned process that consists of parts: planning, study design execution, documentation and which produce conclusion(s).</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Bjoern Peters</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">OBI branch derived</obo:IAO_0000119>
+        <obo:IAO_0000232>Could add specific objective specification</obo:IAO_0000232>
         <obo:IAO_0000232 xml:lang="en">Following OBI call November 2012,26th: it was decided there was no need for adding &quot;achieves objective of drawing conclusion&quot; as existing relations were providing equivalent ability. this note closes the issue and validates the class definition to be part of the OBI core
 editor = PRS</obo:IAO_0000232>
-        <obo:IAO_0000232>Could add specific objective specification</obo:IAO_0000232>
         <obo:OBI_0001847>study</obo:OBI_0001847>
         <rdfs:label xml:lang="en">investigation</rdfs:label>
     </owl:Class>
@@ -3747,8 +3747,8 @@ editor = PRS</obo:IAO_0000232>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000068">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
         <obo:IAO_0000111>reporting party role</obo:IAO_0000111>
-        <obo:IAO_0000112 xml:lang="en">The first section has been pre-designated as the &apos;Reporting Party&apos; section and should be filled with the Reporting Party&apos;s personal information.  http://www.mercedsheriff.com/SelfReporting.htm</obo:IAO_0000112>
         <obo:IAO_0000112>Person who prepares microarray data in MAGE-TAB format and submits to a database, such as ArrayExpress.</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">The first section has been pre-designated as the &apos;Reporting Party&apos; section and should be filled with the Reporting Party&apos;s personal information.  http://www.mercedsheriff.com/SelfReporting.htm</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
         <obo:IAO_0000115 xml:lang="en">a study personnel role played by a party who reports the outcome of a study component</obo:IAO_0000115>
         <obo:IAO_0000116>MO:submitter mapped to this term. So, alternative term &apos;submitter&apos; was added.</obo:IAO_0000116>
@@ -4009,8 +4009,8 @@ In regard to the statement that reagents are &apos;distinct&apos; from the speci
         <obo:IAO_0000112 xml:lang="en">CIP= Certified IRB Professional; http://acronyms.thefreedictionary.com/Certified+IRB+Professional</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
         <obo:IAO_0000115>a role of which inheres in a Homo sapiens and realized during administration and oversight of the daily activities of Institutional Review Boards (IRBs) in the USA</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person:Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000117>Person:Helen Parkinson</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Person:Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000118>certified IRB professional</obo:IAO_0000118>
         <obo:IAO_0000119>WEB: http://en.wikipedia.org/wiki/Certified_IRB_Professional</obo:IAO_0000119>
         <rdfs:label xml:lang="en">role of certified IRB professional</rdfs:label>
@@ -4195,8 +4195,8 @@ editor = PRS</obo:IAO_0000232>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000110">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000250"/>
         <obo:IAO_0000111>pH indicator dye role</obo:IAO_0000111>
-        <obo:IAO_0000112 xml:lang="en">phenol red in RPMI; pH=4 indicator dye (also carries reference role)</obo:IAO_0000112>
         <obo:IAO_0000112>bromophenol blue has a pH indicator dye role</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">phenol red in RPMI; pH=4 indicator dye (also carries reference role)</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
         <obo:IAO_0000115>the role of a dye that is realized when the dye is used in an experiment to measure the pH in a material entity</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Person: Jennifer Fostel</obo:IAO_0000117>
@@ -4231,14 +4231,14 @@ editor = PRS</obo:IAO_0000232>
         <obo:IAO_0000112>liver section; a portion of a culture of cells; a nemotode or other animal once no longer a subject (generally killed); portion of blood from a patient.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">a role borne by a material entity that is gained during a specimen collection process and that can be realized by use of the specimen in an investigation</obo:IAO_0000115>
+        <obo:IAO_0000116>22Jun09.  The definition includes whole organisms, and can include a human.  The link between specimen role and study subject role has been removed.  A specimen taken as part of a case study is not considered to be a population representative, while a specimen taken as representing a population, e.g. person taken from a cohort, blood specimen taken from an animal) would be considered a population representative and would also bear material sample role.</obo:IAO_0000116>
+        <obo:IAO_0000116>Note: definition is in specimen creation objective which is defined as an objective to obtain and store a material entity for potential use as an input during an investigation.</obo:IAO_0000116>
         <obo:IAO_0000116 xml:lang="en">blood taken from animal: animal continues in study, whereas blood has role specimen.
 something taken from study subject, leaves the study and becomes the specimen.</obo:IAO_0000116>
         <obo:IAO_0000116 xml:lang="en">parasite example
 - when parasite in people we study people, people are subjects and parasites are specimen
 - when parasite extracted, they become subject in the following study
 specimen can later be subject.</obo:IAO_0000116>
-        <obo:IAO_0000116>22Jun09.  The definition includes whole organisms, and can include a human.  The link between specimen role and study subject role has been removed.  A specimen taken as part of a case study is not considered to be a population representative, while a specimen taken as representing a population, e.g. person taken from a cohort, blood specimen taken from an animal) would be considered a population representative and would also bear material sample role.</obo:IAO_0000116>
-        <obo:IAO_0000116>Note: definition is in specimen creation objective which is defined as an objective to obtain and store a material entity for potential use as an input during an investigation.</obo:IAO_0000116>
         <obo:IAO_0000117>GROUP:  Role Branch</obo:IAO_0000117>
         <obo:IAO_0000119>OBI</obo:IAO_0000119>
         <obo:IAO_0000233 rdf:resource="https://github.com/obi-ontology/obi/issues/1013"/>
@@ -4468,8 +4468,8 @@ specimen can later be subject.</obo:IAO_0000116>
         <obo:IAO_0000112>Animal protocol review board</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
         <obo:IAO_0000115>the role of a organization that is realized by members reviewing study designs for their agreement with regulations</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person:Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000117>Person:Helen Parkinson</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Person:Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000118>Internal Review Board</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">OBI, CDISC</obo:IAO_0000119>
         <obo:IAO_0000232 xml:lang="en">CDISC definition:  institutional review board; independent ethics committee (IEC). An independent body (a review board or a committee, institutional, regional, national, or supranational) constituted of medical/scientific professionals and non-scientific members, whose responsibility it is to ensure the protection of the rights, safety and well-being of human subjects involved in a trial.</obo:IAO_0000232>
@@ -4715,8 +4715,8 @@ illiterate subject. PharmPK Discussion, http://www.boomer.org/pkin/PK06/PK200625
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
         <obo:IAO_0000115>a role which inheres in a Homo sapiens and is realized during a clinical trial - the impartial witness is independent of the trial and cannot be unfairly influenced by people involved with the trial</obo:IAO_0000115>
         <obo:IAO_0000116 xml:lang="en">impartial witness. A person, who is independent of the trial, who cannot be unfairly influenced by people involved with the trial, who attends the informed consent process if the subject or the subject&apos;s legally acceptable representative cannot read, and who</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">Person: Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000117>Person: Helen Parkinson</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Person: Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000118>impartial witness</obo:IAO_0000118>
         <rdfs:label xml:lang="en">role of impartial witness</rdfs:label>
     </owl:Class>
@@ -4797,8 +4797,8 @@ illiterate subject. PharmPK Discussion, http://www.boomer.org/pkin/PK06/PK200625
         <obo:IAO_0000112 xml:lang="en">The person perform microarray experiments and submit microarray results (including raw data, processed data) with experiment description to ArrayExpress.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">A role borne by an entity and that is realized in a process that is part of an investigation in which an objective is achieved. These processes include, among others: planning, overseeing, funding, reviewing.</obo:IAO_0000115>
-        <obo:IAO_0000116>Philly2013: Historically, this role would have been borne only by humans or organizations. However, we now also want to enable representing investigations run by robot scientists such as ADAM (King et al, Science, 2009)</obo:IAO_0000116>
         <obo:IAO_0000116>Implementing a study means carrying out or performing the study and providing reagents or other materials used in the study and other tasks without which the study would not happen.</obo:IAO_0000116>
+        <obo:IAO_0000116>Philly2013: Historically, this role would have been borne only by humans or organizations. However, we now also want to enable representing investigations run by robot scientists such as ADAM (King et al, Science, 2009)</obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">GROUP:  Role Branch</obo:IAO_0000117>
         <obo:IAO_0000118>investigator</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">OBI</obo:IAO_0000119>
@@ -4995,8 +4995,8 @@ An individual or juridicial or other body authorized under applicable law to con
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
         <obo:IAO_0000115>A dye role that is realized when used to detect live cells in an experiment</obo:IAO_0000115>
         <obo:IAO_0000116>2009-11-10. Tracker: https://sourceforge.net/tracker/?func=detail&amp;aid=2893048&amp;group_id=177891&amp;atid=886178</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">Person: Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000117>Person: Helen Parkinson</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Person: Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000118>vital dye</obo:IAO_0000118>
         <rdfs:label xml:lang="en">vital dye role</rdfs:label>
     </owl:Class>
@@ -6632,8 +6632,8 @@ activity)</obo:IAO_0000115>
         <obo:IAO_0000112 xml:lang="en">A mean calculation which has averaging objective is a descriptive statistics calculation in which the mean is calculated by taking the sum of all of the observations in a data set divided by the total number of observations. It gives a measure of the &apos;center of gravity&apos; for the data set. It is also known as the first moment.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">An averaging objective is a data transformation objective where the aim is to perform mean calculations on the input of the data transformation.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>Elisabetta Manduchi</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000119>PERSON: Elisabetta Manduchi</obo:IAO_0000119>
         <rdfs:label xml:lang="en">averaging objective</rdfs:label>
     </owl:Class>
@@ -7138,8 +7138,8 @@ that has_part some material entity is a material entity. If we add as equivalent
         <obo:IAO_0000111>manufacturing</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">Manufacturing is a process with the intent to produce a processed material which will have a function for future use. A person or organization (having manufacturer role) is a participant in this process</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">This includes a single scientist making a processed material for personal use.</obo:IAO_0000116>
         <obo:IAO_0000116>Manufacturing implies reproducibility and responsibility AR</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">This includes a single scientist making a processed material for personal use.</obo:IAO_0000116>
         <obo:IAO_0000117>PERSON: Bjoern Peters</obo:IAO_0000117>
         <obo:IAO_0000117>PERSON: Frank Gibson</obo:IAO_0000117>
         <obo:IAO_0000117>PERSON: Jennifer Fostel</obo:IAO_0000117>
@@ -7693,11 +7693,11 @@ Eur J Cancer. 2009 Jan;45(1):74-81. PMID: 19008094</obo:IAO_0000112>
         <obo:IAO_0000112>drawing blood from a patient for analysis, collecting a piece of a plant for depositing in a herbarium, buying meat from a butcher in order to measure its protein content in an investigation</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115>A planned process with the objective of collecting a specimen.</obo:IAO_0000115>
+        <obo:IAO_0000116>Note: definition is in specimen creation objective which is defined as an objective to obtain and store a material entity for potential use as an input during an investigation.</obo:IAO_0000116>
         <obo:IAO_0000116>Philly2013: A specimen collection can have as part a material entity acquisition, such as ordering from a bank. The distinction is that specimen collection necessarily involves the creation of a specimen role. However ordering cell lines cells from ATCC for use in an investigation is NOT a specimen collection, because the cell lines already have a specimen role.</obo:IAO_0000116>
         <obo:IAO_0000116>Philly2013: The specimen_role for the specimen is created during the specimen collection process.</obo:IAO_0000116>
         <obo:IAO_0000116>label  changed to &apos;specimen collection process&apos; on 10/27/2014, details see tracker:
 http://sourceforge.net/p/obi/obi-terms/716/</obo:IAO_0000116>
-        <obo:IAO_0000116>Note: definition is in specimen creation objective which is defined as an objective to obtain and store a material entity for potential use as an input during an investigation.</obo:IAO_0000116>
         <obo:IAO_0000117>Bjoern Peters</obo:IAO_0000117>
         <obo:IAO_0000118>specimen collection</obo:IAO_0000118>
         <obo:IAO_0000232>5/31/2012: This process is not necessarily an acquisition, as specimens may be collected from materials already in posession</obo:IAO_0000232>
@@ -22477,8 +22477,8 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">Phosphate buffered saline (abbreviated PBS) is a buffer solution commonly used in biochemistry. It is a salty solution containing sodium chloride, sodium phosphate and in some preparations potassium chloride and potassium phosphate. The buffer helps to maintain a constant pH. The concentration usually matches the human body (isotonic).</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">PERSON: Melanie Courtot</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Tina Boussard</obo:IAO_0000117>
         <obo:IAO_0000117>PERSON: Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Tina Boussard</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">PBS buffer</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">WEB: http://en.wikipedia.org/wiki/Phosphate_buffered_saline</obo:IAO_0000119>
         <rdfs:label xml:lang="en">phosphate buffered saline solution</rdfs:label>
@@ -22821,10 +22821,10 @@ Thyroidectomy during laryngectomy for advanced laryngeal carcinoma--whole organ 
         <obo:IAO_0000117 xml:lang="en">Helen Parkinson</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">Richard Scheuermann</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">Ryan Brinkman</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">Tina Hernandez-Boussard</obo:IAO_0000117>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">data analysis</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">data processing</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">Branch editors</obo:IAO_0000119>
@@ -22947,8 +22947,8 @@ Thyroidectomy during laryngectomy for advanced laryngeal carcinoma--whole organ 
         <obo:IAO_0000111 xml:lang="en">feature extraction objective</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115 xml:lang="en">A feature extraction objective is a data transformation objective where the aim of the data transformation is to generate quantified values from a scanned image.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>Elisabetta Manduchi</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">TERM: http://mged.sourceforge.net/ontologies/MGEDOntology.owl#feature_extraction</obo:IAO_0000119>
         <rdfs:label xml:lang="en">feature extraction objective</rdfs:label>
     </owl:Class>
@@ -23595,8 +23595,8 @@ Thyroidectomy during laryngectomy for advanced laryngeal carcinoma--whole organ 
         <obo:IAO_0000115>A data transformation process in which the Benjamini and Hochberg method sequential p-value procedure  is applied with the aim of correcting false discovery rate</obo:IAO_0000115>
         <obo:IAO_0000116 xml:lang="en">2011-03-31: [PRS]. 
 specified input and output of dt which were missing</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000117>Helen Parkinson</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119>Helen Parkinson</obo:IAO_0000119>
         <rdfs:label xml:lang="en">Benjamini and Hochberg false discovery rate correction method</rdfs:label>
     </owl:Class>
@@ -23665,8 +23665,8 @@ specified input and output of dt which were missing</obo:IAO_0000116>
         <obo:IAO_0000111 xml:lang="en">k-means clustering</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115 xml:lang="en">A k-means clustering is a data transformation which achieves a class discovery or partitioning objective, which takes as input a collection of objects (represented as points in multidimensional space) and which partitions them into a specified number k of clusters. The algorithm attempts to find the centers of natural clusters in the data. The most common form of the algorithm starts by partitioning the input points into k initial sets, either at random or using some heuristic data. It then calculates the mean point, or centroid, of each set. It constructs a new partition by associating each point with the closest centroid. Then the centroids are recalculated for the new clusters, and the algorithm repeated by alternate applications of these two steps until convergence, which is obtained when the points no longer switch clusters (or alternatively centroids are no longer changed).</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>Elisabetta Manduchi</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">WEB: http://en.wikipedia.org/wiki/K-means</obo:IAO_0000119>
         <rdfs:label xml:lang="en">k-means clustering</rdfs:label>
@@ -23778,8 +23778,8 @@ specified input and output of dt which were missing</obo:IAO_0000116>
         <obo:IAO_0000115>A data transformation in which the Benjamini and Yekutieli method is applied with the aim of correcting false discovery rate</obo:IAO_0000115>
         <obo:IAO_0000116 xml:lang="en">2011-03-31: [PRS]. 
 specified input and output of dt which were missing</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000117>Helen Parkinson</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119>Helen Parkinson</obo:IAO_0000119>
         <rdfs:label xml:lang="en">Benjamini and Yekutieli false discovery rate correction method</rdfs:label>
     </owl:Class>
@@ -24040,8 +24040,8 @@ specified input and output of dt which were missing</obo:IAO_0000116>
         <obo:IAO_0000111 xml:lang="en">continuum mass spectrum</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
         <obo:IAO_0000115 xml:lang="en">A continuum mass spectrum is a data transformation that contains the full profile of the detected signals for a given ion.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Tina Hernandez-Boussard</obo:IAO_0000117>
         <obo:IAO_0000117>PERSON: James Malone</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Tina Hernandez-Boussard</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">PERSON: Tina Boussard</obo:IAO_0000119>
         <rdfs:label xml:lang="en">continuum mass spectrum analysis</rdfs:label>
     </owl:Class>
@@ -24120,8 +24120,8 @@ specified input and output of dt which were missing</obo:IAO_0000116>
 Also added restriction to specify the output to be a FWER adjusted p-value
 
 The &apos;editor preferred term&apos; should be removed</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000117>Person:Helen Parkinson</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119>WEB: http://en.wikipedia.org/wiki/Holm%E2%80%93Bonferroni_method</obo:IAO_0000119>
         <rdfs:label xml:lang="en">Holm-Bonferroni family-wise error rate correction method</rdfs:label>
     </owl:Class>
@@ -24219,8 +24219,8 @@ TO BE DEALT WITH STILL BY RICHARD.  JAMES</obo:IAO_0000232>
         <obo:IAO_0000116 xml:lang="en">2011-03-31: [PRS]. 
 creating a defined class by specifying the necessary output of dt
 allows correct classification of FWER dt</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000117>Monnie McGee</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">FWER correction</obo:IAO_0000118>
         <obo:IAO_0000119>Dudoit, Sandrine and van der Laan, Mark J. (2008) Multiple Testing Procedures with Applications to Genomics.  New York: Springer , p. 19</obo:IAO_0000119>
         <rdfs:label xml:lang="en">family wise error rate correction method</rdfs:label>
@@ -24434,8 +24434,8 @@ allows correct classification of FWER dt</obo:IAO_0000116>
         <obo:IAO_0000115 xml:lang="en">Longitudinal analysis is a data transformation used to perform repeated observations of the same items over long periods of time.</obo:IAO_0000115>
         <obo:IAO_0000117>PERSON: James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>PERSON: Tina Boussard</obo:IAO_0000117>
-        <obo:IAO_0000118 xml:lang="en">longitudinal data analysis</obo:IAO_0000118>
         <obo:IAO_0000118>correlation analysis</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">longitudinal data analysis</obo:IAO_0000118>
         <rdfs:label xml:lang="en">longitudinal data analysis</rdfs:label>
     </owl:Class>
     
@@ -25004,8 +25004,8 @@ In this equation b0 is the regression coefficient for the intercept and the bi v
         <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">Melanie Courtot</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">Tina Boussard</obo:IAO_0000117>
-        <obo:IAO_0000118 xml:lang="en">visualization</obo:IAO_0000118>
         <obo:IAO_0000118>data encoding as image</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">visualization</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">PERSON: Elisabetta Manduchi</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">PERSON: James Malone</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">PERSON: Melanie Courtot</obo:IAO_0000119>
@@ -25761,8 +25761,8 @@ information_encoding
         <obo:IAO_0000111 xml:lang="en">agglomerative hierarchical clustering</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115 xml:lang="en">An agglomerative hierarchical clustering is a hierarchical clustering which starts with separate clusters and then successively combines these clusters until there is only one cluster remaining.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>Elisabetta Manduchi</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000118>bottom-up hierarchical clustering</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">PERSON: Elisabetta Manduchi</obo:IAO_0000119>
         <rdfs:label xml:lang="en">agglomerative hierarchical clustering</rdfs:label>
@@ -25777,8 +25777,8 @@ information_encoding
         <obo:IAO_0000111 xml:lang="en">divisive hierarchical clustering</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115 xml:lang="en">A divisive hierarchical clustering is a hierarchical clustering which starts with a single cluster and then successively splits resulting clusters until only clusters of individual objects remain.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>Elisabetta Manduchi</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000118>top-down hierarchical clustering</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">PERSON: Elisabetta Manduchi</obo:IAO_0000119>
         <rdfs:label xml:lang="en">divisive hierarchical clustering</rdfs:label>
@@ -25809,8 +25809,8 @@ information_encoding
         <obo:IAO_0000111 xml:lang="en">data vector reduction objective</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115 xml:lang="en">Data vector reduction is a data transformation objective in which k m-dimensional input vectors are reduced to j m-dimensional output vectors, where j is smaller than k.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Richard H. Scheuermann</obo:IAO_0000117>
         <obo:IAO_0000117>James Malone</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Richard H. Scheuermann</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">PERSON: Richard H. Scheuermann</obo:IAO_0000119>
         <rdfs:label xml:lang="en">data vector reduction objective</rdfs:label>
     </owl:Class>
@@ -25916,8 +25916,8 @@ information_encoding
         <obo:IAO_0000116 xml:lang="en">2011-03-31: [PRS]. 
 creating a defined class by specifying the necessary output of dt
 allows correct classification of FDR dt</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000117>Monnie McGee</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">FDR correction method</obo:IAO_0000118>
         <obo:IAO_0000119>Dudoit, Sandrine and van der Laan, Mark J. (2008) Multiple Testing Procedures with Applications to Genomics.  New York: Springer , p. 21 and http://www.wikidoc.org/index.php/False_discovery_rate</obo:IAO_0000119>
         <rdfs:label xml:lang="en">false discovery rate correction method</rdfs:label>
@@ -26009,12 +26009,12 @@ allows correct classification of FDR dt</obo:IAO_0000116>
         <obo:IAO_0000115 xml:lang="en">A normalization objective is a data transformation objective where the aim is to remove
 systematic sources of variation to put the data on equal footing in order
 to create a common base for comparisons.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>Elisabetta Manduchi</obo:IAO_0000117>
         <obo:IAO_0000117>Helen Parkinson</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">PERSON: James Malone</obo:IAO_0000119>
+        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000119>PERSON: Elisabetta Manduchi</obo:IAO_0000119>
         <obo:IAO_0000119>PERSON: Helen Parkinson</obo:IAO_0000119>
+        <obo:IAO_0000119 xml:lang="en">PERSON: James Malone</obo:IAO_0000119>
         <rdfs:label xml:lang="en">data normalization objective</rdfs:label>
     </owl:Class>
     
@@ -26120,8 +26120,8 @@ to create a common base for comparisons.</obo:IAO_0000115>
         <obo:IAO_0000112 xml:lang="en">A k-means clustering which has partitioning objective is a data transformation in which the input data is partitioned into k output sets.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">A partitioning objective is a data transformation objective where the aim is to generate a collection of disjoint non-empty subsets whose union equals a non-empty input set.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>Elisabetta Manduchi</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000119>PERSON: Elisabetta Manduchi</obo:IAO_0000119>
         <rdfs:label xml:lang="en">partitioning objective</rdfs:label>
     </owl:Class>
@@ -26135,8 +26135,8 @@ to create a common base for comparisons.</obo:IAO_0000115>
         <obo:IAO_0000111 xml:lang="en">background correction objective</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115 xml:lang="en">A background correction objective is a data transformation objective where the aim is to remove irrelevant contributions from the measured signal, e.g. those due to instrument noise or sample preparation.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>Elisabetta Manduchi</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000119>PERSON: Elisabetta Manduchi</obo:IAO_0000119>
         <rdfs:label xml:lang="en">background correction objective</rdfs:label>
     </owl:Class>
@@ -26150,8 +26150,8 @@ to create a common base for comparisons.</obo:IAO_0000115>
         <obo:IAO_0000111 xml:lang="en">curve fitting objective</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115 xml:lang="en">A curve fitting objective is a data transformation objective in which the aim is to find a curve which matches a series of data points and possibly other constraints.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000117>Elisabetta Manduchi</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
         <obo:IAO_0000119>PERSON: Elisabetta Manduchi</obo:IAO_0000119>
         <rdfs:label xml:lang="en">curve fitting objective</rdfs:label>
     </owl:Class>
@@ -26231,9 +26231,9 @@ to create a common base for comparisons.</obo:IAO_0000115>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">A class discovery objective (sometimes called unsupervised classification) is a data transformation objective where the aim is to organize input data  (typically vectors of attributes) into classes, where the number of classes and their specifications are not known a priori. Depending on usage, the class assignment can be definite or probabilistic.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
+        <obo:IAO_0000118>clustering objective</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">discriminant analysis objective</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">unsupervised classification objective</obo:IAO_0000118>
-        <obo:IAO_0000118>clustering objective</obo:IAO_0000118>
         <obo:IAO_0000119>PERSON: Elisabetta Manduchi</obo:IAO_0000119>
         <obo:IAO_0000119>PERSON: James Malone</obo:IAO_0000119>
         <rdfs:label xml:lang="en">class discovery objective</rdfs:label>
@@ -26250,8 +26250,8 @@ to create a common base for comparisons.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">A class prediction objective (sometimes called supervised classification) is a data transformation objective where the aim is to create a predictor from training data through a machine learning technique. The training data consist of pairs of objects (typically vectors of attributes) and
 class labels for these objects. The resulting predictor can be used to attach class labels to any valid novel input object. Depending on usage, the prediction can be definite or probabilistic. A classification is learned from the training data and can then be tested on test data.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">James Malone</obo:IAO_0000117>
-        <obo:IAO_0000118 xml:lang="en">supervised classification objective</obo:IAO_0000118>
         <obo:IAO_0000118>classification objective</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">supervised classification objective</obo:IAO_0000118>
         <obo:IAO_0000119>PERSON: Elisabetta Manduchi</obo:IAO_0000119>
         <obo:IAO_0000119>PERSON: James Malone</obo:IAO_0000119>
         <rdfs:label xml:lang="en">class prediction objective</rdfs:label>
@@ -28273,15 +28273,15 @@ defines and states the requirements (positive or negative) for an entity to be c
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000111 xml:lang="en">administering substance in vivo</obo:IAO_0000111>
-        <obo:IAO_0000112 xml:lang="en">injecting mice with 10 ug morphine intranasally, a patient taking two pills of 1 mg aspirin orally</obo:IAO_0000112>
         <obo:IAO_0000112>Balb/c mice received an intracameral or subconjunctival injection of trinitrophenylated spleen cells</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">injecting mice with 10 ug morphine intranasally, a patient taking two pills of 1 mg aspirin orally</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115>A process by which a substance is intentionally given to an organism resulting in exposure of the organism to that substance.</obo:IAO_0000115>
+        <obo:IAO_0000116>2009-11-10. Tracker: https://sourceforge.net/tracker/?func=detail&amp;aid=2893050&amp;group_id=177891&amp;atid=886178</obo:IAO_0000116>
         <obo:IAO_0000116 xml:lang="en">Different routes and means of administration should go as children underneath this</obo:IAO_0000116>
         <obo:IAO_0000116>Update the definition based on the discussion. Details see the tracker:
 https://sourceforge.net/p/obi/obi-terms/738/</obo:IAO_0000116>
         <obo:IAO_0000116 xml:lang="en">needs roles such as perturber and perturbee (children of input role). Perturb is too strong. Host might be the name for one role. Others considered: Doner, Donated, Acceptor.</obo:IAO_0000116>
-        <obo:IAO_0000116>2009-11-10. Tracker: https://sourceforge.net/tracker/?func=detail&amp;aid=2893050&amp;group_id=177891&amp;atid=886178</obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">Bjoern Peters</obo:IAO_0000117>
         <obo:IAO_0000117>Person:Bjoern Peters</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">IEDB</obo:IAO_0000119>
@@ -28322,10 +28322,10 @@ https://sourceforge.net/p/obi/obi-terms/738/</obo:IAO_0000116>
         <obo:IAO_0000112>Downloading a 3D structure from the PDB. Purchasing antibodies from sigma.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">the planned process of gaining possession of a continuant.</obo:IAO_0000115>
+        <obo:IAO_0000116>5/31/2012 - OBI workshop: This process is not implying ownership of the material / information.</obo:IAO_0000116>
         <obo:IAO_0000116 xml:lang="en">Following OBI call November 2012,5th:
 addition of a restriction to acquisition class to capture the need of having selection criteria
 Relates to the creation of a class &apos;selection rule&apos;</obo:IAO_0000116>
-        <obo:IAO_0000116>5/31/2012 - OBI workshop: This process is not implying ownership of the material / information.</obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">Bjoern Peters</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">IEDB</obo:IAO_0000119>
         <obo:IAO_0000232 xml:lang="en">This needs to be fleshed out and logical definitions added that will allow to place the children terms automatically under acquisition</obo:IAO_0000232>
@@ -28364,8 +28364,8 @@ Relates to the creation of a class &apos;selection rule&apos;</obo:IAO_0000116>
         <obo:IAO_0000112 xml:lang="en">Acquiring 50 C57BL/6 mice bred in the animal facility of the institute as a service to investigators. Purchasing 1 mg of peptides synthesized by Mimotopes at 80% purity. Getting a gift of purified CD4+ specific antibodies presented by Stephen Schoenberger at LIAI.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">An acquisition in which possession of a material entity is gained.</obo:IAO_0000115>
-        <obo:IAO_0000116>This excludes processes that create or change materials, such as material transformations.</obo:IAO_0000116>
         <obo:IAO_0000116>The assumption is that the object already exists in its current state, e.g, an available mouse strain purchased from the Jackson Lab, this is the differentia from specimen creation</obo:IAO_0000116>
+        <obo:IAO_0000116>This excludes processes that create or change materials, such as material transformations.</obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">Bjoern Peters, Alan Ruttenberg, Helen Parkinson</obo:IAO_0000117>
         <obo:IAO_0000118>material procurement</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">IEDB</obo:IAO_0000119>
@@ -28789,8 +28789,8 @@ discussed on obi-dev call 9/28/2015, details see: https://sourceforge.net/p/obi/
         <obo:IAO_0000112 xml:lang="en">The use of M-MLV reverse transcriptase from the Moloney murine leukemia virus to transcribe an RNA sample into cDNA</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115 xml:lang="en">a protocol with the objective to transcribe single-stranded RNA into complementary DNA (cDNA)</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">We need to indicate the relationship between the cDNA generated and the RNA that was used as a template. This may be outside of the OBI scope</obo:IAO_0000116>
         <obo:IAO_0000116>It could also be added that the reverse transcriptase is bearer of a GO:0003964 RNA-directed DNA polymerase activity, which is realized in this process.</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">We need to indicate the relationship between the cDNA generated and the RNA that was used as a template. This may be outside of the OBI scope</obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">PERSON:Kevin Clancy</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">OBI branch derived</obo:IAO_0000119>
         <rdfs:label xml:lang="en">artificially induced reverse transcription</rdfs:label>


### PR DESCRIPTION
Fixes the problem with #1679, which was ultimately caused by https://github.com/ontodev/robot/issues/1090. The serialization should be stable going forward between the latest ROBOT and Protege, maybe with the small difference of the OWLAPI version ID at the end of the file.