### PR TITLE
replace documentation link to point to homepage instead of GiHub wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The Ontology for Biomedical Investigations (OBI) helps you communicate clearly about scientific investigations by defining more than 2500 terms for assays, devices, objectives, and more.
 
-This is the developer repository for OBI. You can download the most up-to-date OBI products [here](http://obofoundry.org/ontology/obi.html) and learn more about OBI through [our documentation](https://github.com/obi-ontology/obi/wiki).
+This is the developer repository for OBI. You can download the most up-to-date OBI products [here](http://obofoundry.org/ontology/obi.html) and learn more about OBI through [our documentation](http://obi-ontology.org/docs/).
 
 # Editing
 


### PR DESCRIPTION
Assuming that the information regarding the documentation on the wiki of this repo is less recent and the official homepage is meant as the point of entry for documentation on OBI, this PR replaces the link in the README to point to the homepage documentation section.

closes #1696 