### PR TITLE
Fix rdfs:label for 'planned irradiation'

### DIFF
--- a/src/ontology/obi-edit.owl
+++ b/src/ontology/obi-edit.owl
@@ -27348,7 +27348,7 @@ Nat Protoc. 2008;3(10):1550-8. PMID: 18802436</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A planned process by which a material entity is exposed to radiative energy, which could be ionizing radiation (such as gamma rays, X-rays, charged particles or neutrons) or non-ionizing radiation (such as UV light or microwaves)</obo:IAO_0000115>
         <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119>adapted from wikipedia (http://en.wikipedia.org/wiki/Irradiation)</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">irradiation</rdfs:label>
+        <rdfs:label xml:lang="en">planned irradiation</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
#1715 should also have updated the rdfs:label for this term.