### PR TITLE
Do not assert that minQualifiedCardinality is an AP

### DIFF
--- a/src/ontology/obi-edit.owl
+++ b/src/ontology/obi-edit.owl
@@ -502,12 +502,6 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
     
 
 
-    <!-- http://www.w3.org/2002/07/owl#minQualifiedCardinality -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#minQualifiedCardinality"/>
-    
-
-
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //


### PR DESCRIPTION
We have been asserting that owl:minQualifiedCardinality is an owl:AnnotationProperty. This is not true and it violated the OWL DL profile. A recent update to OWLAPI 4.5.26 revealed this problem.