### PR TITLE
Add editor's note about relation b/t OBI & CHEBI: solvent/solvent role

### DIFF
--- a/src/ontology/obi-edit.owl
+++ b/src/ontology/obi-edit.owl
@@ -26641,6 +26641,7 @@ determinations of compounds.</obo:IAO_0000115>
         <obo:IAO_0000112 xml:lang="en">PMID: 18373502.Transfusion. 2008 Mar 25. Solvent/detergent treatment of platelet concentrates enhances the release of growth factors.</obo:IAO_0000112>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:IAO_0000115 xml:lang="en">solvent role is a role which inheres in a molecular entity capable of ensuring the dissolution of another chemical entity and realized by the process of solvation</obo:IAO_0000115>
+        <obo:IAO_0000116>The related class CHEBI:&quot;solvent&quot; (CHEBI:46787) denotes material entities themselves, while this OBI class denotes the role that a material entity can play in a mixture. The OBI modeling was needed as what is considered a solvent in a mixture can depend on the intent of the person creating the mixture. It would be great if this could be dealt with in CHEBI itself. See also https://github.com/obi-ontology/obi/issues/1771.</obo:IAO_0000116>
         <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119>adpated from wikipedia (http://en.wikipedia.org/wiki/Solvatation)</obo:IAO_0000119>
         <rdfs:label xml:lang="en">solvent role</rdfs:label>


### PR DESCRIPTION
Closes #1771. Adds an editor's note to OBI:"solvent role" specifying the difference between it and CHEBI:"solvent," using language proposed by @bpeters42.