### PR TITLE
Add terms to core.txt that were missing after IAO import module update

### DIFF
--- a/src/ontology/OntoFox_inputs/IAO_input.txt
+++ b/src/ontology/OntoFox_inputs/IAO_input.txt
@@ -11,8 +11,10 @@ http://purl.obolibrary.org/obo/IAO_0000003 # measurement unit label
 http://purl.obolibrary.org/obo/IAO_0000004 # has measurement value
 http://purl.obolibrary.org/obo/IAO_0000005 # objective specification
 http://purl.obolibrary.org/obo/IAO_0000006 # narrative object
+http://purl.obolibrary.org/obo/IAO_0000007 # action specification
 http://purl.obolibrary.org/obo/IAO_0000009 # datum label
 http://purl.obolibrary.org/obo/IAO_0000010 # software
+http://purl.obolibrary.org/obo/IAO_0000015 # information carrier
 http://purl.obolibrary.org/obo/IAO_0000027 # data item
 http://purl.obolibrary.org/obo/IAO_0000028 # symbol
 http://purl.obolibrary.org/obo/IAO_0000030 # information content entity
@@ -40,6 +42,7 @@ http://purl.obolibrary.org/obo/IAO_0000183 # dendrogram
 http://purl.obolibrary.org/obo/IAO_0000184 # scatter plot
 http://purl.obolibrary.org/obo/IAO_0000219 # denotes
 http://purl.obolibrary.org/obo/IAO_0000221 # is quality measurement of
+http://purl.obolibrary.org/obo/IAO_0000235 # denoted by
 http://purl.obolibrary.org/obo/IAO_0000300 # textual entity
 http://purl.obolibrary.org/obo/IAO_0000306 # table
 http://purl.obolibrary.org/obo/IAO_0000310 # document
@@ -56,6 +59,7 @@ http://purl.obolibrary.org/obo/IAO_0000572 # documenting
 http://purl.obolibrary.org/obo/IAO_0000573 # line graph
 http://purl.obolibrary.org/obo/IAO_0000574 # assigning a centrally registered identifier
 http://purl.obolibrary.org/obo/IAO_0000577 # centrally registered identifier symbol
+http://purl.obolibrary.org/obo/IAO_0000579 # centrally registered identifier registry
 http://purl.obolibrary.org/obo/IAO_0000594 # software application
 
 [Top level source term URIs and target direct superclass URIs]

--- a/src/ontology/OntoFox_outputs/IAO_imports.owl
+++ b/src/ontology/OntoFox_outputs/IAO_imports.owl
@@ -126,6 +126,17 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000235 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000235">
+        <obo:IAO_0000111 xml:lang="en">denoted by</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">inverse of the relation &apos;denotes&apos;</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">denoted by</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000407 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000407">
@@ -180,6 +191,52 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000001">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <obo:IAO_0000111 xml:lang="en">entity</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">entity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
+        <obo:IAO_0000111 xml:lang="en">continuant</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">An entity that exists in full at any time in which it exists at all, persists through time while maintaining its identity and has no temporal parts.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">continuant</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000019 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000019">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
+        <obo:IAO_0000111 xml:lang="en">quality</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">quality</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000020 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000020">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <obo:IAO_0000111 xml:lang="en">specifically dependent continuant</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">b is a specifically dependent continuant = Def. b is a continuant &amp; there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">specifically dependent continuant</rdfs:label>
+    </owl:Class>
     
 
 
@@ -243,6 +300,18 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000007 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000007">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000033"/>
+        <obo:IAO_0000111 xml:lang="en">action specification</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">A directive information entity that describes an action the bearer will take.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">action specification</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000009 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000009">
@@ -264,6 +333,18 @@
 interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label xml:lang="en">software</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000015 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000015">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
+        <obo:IAO_0000111 xml:lang="en">information carrier</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">A quality of an information bearer that imparts the information content</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">information carrier</rdfs:label>
     </owl:Class>
     
 
@@ -778,6 +859,18 @@ points together with a line.</obo:IAO_0000115>
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000579 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000579">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0020020"/>
+        <obo:IAO_0000111 xml:lang="en">centrally registered identifier registry</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">A code set of CRID records, each consisting of a CRID symbol and additional information which was recorded in the code set through an assigning a centrally registered identifier process.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">centrally registered identifier registry</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000594 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000594">
@@ -786,6 +879,18 @@ points together with a line.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">A software application is software that can be directly executed by some processing unit.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label xml:lang="en">software application</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0020020 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0020020">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
+        <obo:IAO_0000111 xml:lang="en">code set</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">An information content entity that is a collection of other information content entities that has been created to identify or annotate things in a specified domain, and where the intention of its creators is that the collection has a one-to-one correspondence with those things.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">code set</rdfs:label>
     </owl:Class>
     
 

--- a/src/ontology/views/core.txt
+++ b/src/ontology/views/core.txt
@@ -28,6 +28,13 @@ http://purl.obolibrary.org/obo/OBI_0000471 # study design execution
 http://purl.obolibrary.org/obo/OBI_0000750 # study design independent variable
 http://purl.obolibrary.org/obo/OBI_0000097 # study subject role
 http://purl.obolibrary.org/obo/OBI_0001908 # testable hypothesis
+http://purl.obolibrary.org/obo/BFO_0000001 # entity
+http://purl.obolibrary.org/obo/IAO_0000007 # action specification
+http://purl.obolibrary.org/obo/IAO_0000015 # information carrier
+http://purl.obolibrary.org/obo/IAO_0000100 # data set
+http://purl.obolibrary.org/obo/IAO_0000310 # document
+http://purl.obolibrary.org/obo/IAO_0000578 # centrally registered identifier
+http://purl.obolibrary.org/obo/IAO_0000579 # centrally registered identifier registry
 
 # Outer Core
 http://purl.obolibrary.org/obo/GO_0008150     # biological_process
@@ -68,6 +75,10 @@ http://purl.obolibrary.org/obo/IAO_0010000 # has axiom label
 http://purl.obolibrary.org/obo/OBI_0001847 # ISA alternative term
 http://purl.obolibrary.org/obo/OBI_9991118 # IEDB alternative term
 http://purl.obolibrary.org/obo/RO_0001900  # temporal interpretation
+
+# Object Properties
+http://purl.obolibrary.org/obo/IAO_0000219 # denotes
+http://purl.obolibrary.org/obo/IAO_0000235 # denoted by
 
 #Strip Anonymous SubClassOf Class Expressions
 #strip http://purl.obolibrary.org/obo/CL_0000010  cultured cell


### PR DESCRIPTION
Adds 2 object properties and 7 classes that were dropped from obi-core after the IAO import module update to `src/ontology/views/core.txt`.