### PR TITLE
Remove references to 3 obsoleted GO classes in obi-edit

### DIFF
--- a/src/ontology/obi-edit.owl
+++ b/src/ontology/obi-edit.owl
@@ -2259,12 +2259,6 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GO_0006306 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0006306"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GO_0006338 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0006338"/>
@@ -2336,12 +2330,6 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
     <!-- http://purl.obolibrary.org/obo/GO_0010573 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0010573"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GO_0016570 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0016570"/>
     
 
 
@@ -2664,12 +2652,6 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
     <!-- http://purl.obolibrary.org/obo/GO_0043565 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0043565"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GO_0044030 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044030"/>
     
 
 


### PR DESCRIPTION
I could've sworn I did this in #1814, but apparently I didn't—my bad. This PR removes a few lines from obi-edit to get rid of the obsoleted GO terms "DNA methylation" (GO:0006306), "regulation of DNA methylation" (GO:0044030), and "histone modification" (GO:0016570).