### PR TITLE
Pre-COB-transition minor axiom tweaks

### DIFF
--- a/src/ontology/OntoFox_inputs/SO_input.txt
+++ b/src/ontology/OntoFox_inputs/SO_input.txt
@@ -19,7 +19,7 @@ http://purl.obolibrary.org/obo/SO_0005836 #regulatory_region
 
 [Top level source term URIs and target direct superclass URIs]
 http://purl.obolibrary.org/obo/SO_0000001 # region
-subClassOf http://purl.obolibrary.org/obo/BFO_0000031 # generically dependent continuant
+subClassOf http://purl.obolibrary.org/obo/BFO_0000040 # material entity
 http://purl.obolibrary.org/obo/SO_0000104 # polypeptide
 subClassOf http://purl.obolibrary.org/obo/SO_0000001 # region
 http://purl.obolibrary.org/obo/SO_0000148 # supercontig

--- a/src/ontology/OntoFox_outputs/SO_imports.owl
+++ b/src/ontology/OntoFox_outputs/SO_imports.owl
@@ -62,9 +62,9 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/BFO_0000031 -->
+    <!-- http://purl.obolibrary.org/obo/BFO_0000040 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000031"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/>
     
 
 
@@ -77,7 +77,7 @@
     <!-- http://purl.obolibrary.org/obo/SO_0000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000001">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
         <obo:IAO_0000111>region</obo:IAO_0000111>
         <obo:IAO_0000115>A sequence_feature with an extent greater than zero. A nucleotide region is composed of bases and a polypeptide region is composed of amino acids.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/so.owl"/>

--- a/src/ontology/obi-edit.owl
+++ b/src/ontology/obi-edit.owl
@@ -13611,30 +13611,20 @@ http://www.pdb.org/pdb/download/downloadFile.do?fileFormat=pdb&amp;compression=N
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
                                 <owl:someValuesFrom>
-                                    <owl:Class>
-                                        <owl:intersectionOf rdf:parseType="Collection">
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000052"/>
+                                        <owl:someValuesFrom>
                                             <owl:Class>
                                                 <owl:unionOf rdf:parseType="Collection">
-                                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000016"/>
-                                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000019"/>
+                                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0100026"/>
+                                                    <owl:Restriction>
+                                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
+                                                    </owl:Restriction>
                                                 </owl:unionOf>
                                             </owl:Class>
-                                            <owl:Restriction>
-                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000052"/>
-                                                <owl:someValuesFrom>
-                                                    <owl:Class>
-                                                        <owl:unionOf rdf:parseType="Collection">
-                                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0100026"/>
-                                                            <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
-                                                            </owl:Restriction>
-                                                        </owl:unionOf>
-                                                    </owl:Class>
-                                                </owl:someValuesFrom>
-                                            </owl:Restriction>
-                                        </owl:intersectionOf>
-                                    </owl:Class>
+                                        </owl:someValuesFrom>
+                                    </owl:Restriction>
                                 </owl:someValuesFrom>
                             </owl:Restriction>
                         </owl:intersectionOf>


### PR DESCRIPTION
This PR contains two minor tweaks already agreed upon in #1853, because they are possible to do in advance, and doing them now will make automating the transition slightly easier. The changes are:
* Simplify the axiom for "comparative phenotypic assessment" so that it doesn't reference GDC.
* Import SO:"region" as a subclass of material entity instead of GDC.