### PR TITLE
Pre-COB-transition: Specify CHEBI:'deuterium atom' is a subclass of atom

### DIFF
--- a/src/ontology/OntoFox_inputs/ChEBI_input.txt
+++ b/src/ontology/OntoFox_inputs/ChEBI_input.txt
@@ -163,6 +163,8 @@ http://purl.obolibrary.org/obo/CHEBI_28619 # acrylamide
 subClassOf http://purl.obolibrary.org/obo/CHEBI_23367 # molecular entity
 http://purl.obolibrary.org/obo/CHEBI_29191 # hydroxyl
 subClassOf http://purl.obolibrary.org/obo/CHEBI_23367 # molecular entity
+http://purl.obolibrary.org/obo/CHEBI_29237 # deuterium atom
+subClassOf http://purl.obolibrary.org/obo/CHEBI_33250 # atom
 http://purl.obolibrary.org/obo/CHEBI_30682 # ruthenium atom
 subClassOf http://purl.obolibrary.org/obo/CHEBI_23367 # molecular entity
 http://purl.obolibrary.org/obo/CHEBI_31624 # fluorescein (lactone form)

--- a/src/ontology/OntoFox_outputs/ChEBI_imports.owl
+++ b/src/ontology/OntoFox_outputs/ChEBI_imports.owl
@@ -660,7 +660,6 @@
     <!-- http://purl.obolibrary.org/obo/CHEBI_29237 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_29237">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
         <obo:IAO_0000111>deuterium atom</obo:IAO_0000111>
         <obo:IAO_0000115>The stable isotope of hydrogen with relative atomic mass 2.014102 and a natural abundance of 0.0115 atom percent (from Greek deltaepsilonupsilontauepsilonrhoomicronnu, second).</obo:IAO_0000115>


### PR DESCRIPTION
Another tweak for the ease of the COB transition. Currently, we don't explicitly set the parent class of CHEBI:'deuterium atom', unlike all other atom terms we import form CHEBI. OntoFox imports it as a subclass of both CHEBI:atom and CHEBI:molecular entity, which is accurate within CHEBI but which in the COB transition becomes COB:atom and COB:molecule, which are disjoint. This PR sets the parent of 'deuterium atom' as 'atom' to fix this, in line with our imports of other atom terms.