### PR TITLE
Add subclass axiom for ChEBI:hormone to stop it from floating to the top

### DIFF
--- a/src/ontology/OntoFox_inputs/ChEBI_input.txt
+++ b/src/ontology/OntoFox_inputs/ChEBI_input.txt
@@ -150,6 +150,8 @@ http://purl.obolibrary.org/obo/CHEBI_23528 # cytochalasin
 subClassOf http://purl.obolibrary.org/obo/CHEBI_23367 # molecular entity
 http://purl.obolibrary.org/obo/CHEBI_23995 # N-ethyl-N-nitrosourea
 subClassOf http://purl.obolibrary.org/obo/CHEBI_23367 # molecular entity
+http://purl.obolibrary.org/obo/CHEBI_24621 # hormone
+subClassOf http://purl.obolibrary.org/obo/CHEBI_23367 # molecular entity
 http://purl.obolibrary.org/obo/CHEBI_24636 # proton
 subClassOf http://purl.obolibrary.org/obo/CHEBI_23367 # molecular entity
 http://purl.obolibrary.org/obo/CHEBI_25078 # luciferin

--- a/src/ontology/OntoFox_outputs/ChEBI_imports.owl
+++ b/src/ontology/OntoFox_outputs/ChEBI_imports.owl
@@ -464,6 +464,7 @@
     <!-- http://purl.obolibrary.org/obo/CHEBI_24621 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24621">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
         <obo:IAO_0000111>hormone</obo:IAO_0000111>
         <obo:IAO_0000115>Originally referring to an endogenous compound that is formed in specialized organ or group of cells and carried to another organ or group of cells, in the same organism, upon which it has a specific regulatory function, the term is now commonly used to include non-endogenous, semi-synthetic and fully synthetic analogues of such compounds.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>


### PR DESCRIPTION
At some point recently, ChEBI:hormone started floating to the top of the OBI hierarchy. This PR refreshes the ChEBI import and adds a subclass axiom for ChEBI:hormone to fix this.