### PR TITLE
Minor fix to ROBOT command script

### DIFF
--- a/src/obi/cmd.py
+++ b/src/obi/cmd.py
@@ -6,8 +6,8 @@ IRI_base = "http://purl.obolibrary.org/obo/obi/dev/import/"
 ROBOT = ["java", "-jar", "build/robot.jar", "--prefix", "REO: http://purl.obolibrary.org/obo/REO_"]
 
 
-def check_relation_length(relation_path):
-    size = os.path.getsize(relation_path)
+def check_file_length(path):
+    size = os.path.getsize(path)
     if size == 0:
         return False
     else:
@@ -107,7 +107,7 @@ def build_robot_module(ontology):
     ]
     mireot_command = ROBOT + mireot_args
     subset_command = ROBOT + subset_args
-    if check_relation_length(relation):
+    if check_file_length(ignore):
         subset_command += remove_args
     subset_command += finalize_args
     run(mireot_command)


### PR DESCRIPTION
This is a minor bug fix for one of the scripts added in #1923. The script was using a condition dependent on the length of the wrong file; this corrects it.