### PR TITLE
Fix floating ChEBI terms

### DIFF
--- a/src/ontology/OntoFox_inputs/ChEBI_input.txt
+++ b/src/ontology/OntoFox_inputs/ChEBI_input.txt
@@ -45,7 +45,7 @@ http://purl.obolibrary.org/obo/CHEBI_24621 # hormone
 http://purl.obolibrary.org/obo/CHEBI_24636 # proton
 http://purl.obolibrary.org/obo/CHEBI_24875 # iron cation
 http://purl.obolibrary.org/obo/CHEBI_25078 # luciferin
-http://purl.obolibrary.org/obo/CHEBI_25555 # nitrogen
+http://purl.obolibrary.org/obo/CHEBI_25555 # nitrogen atom
 http://purl.obolibrary.org/obo/CHEBI_26710 # sodium chloride
 http://purl.obolibrary.org/obo/CHEBI_27226 # uric acid
 http://purl.obolibrary.org/obo/CHEBI_27889 # lead(0)
@@ -130,6 +130,8 @@ http://purl.obolibrary.org/obo/CHEBI_472552 # 5-bromo-2'-deoxyuridine
 [Top level source term URIs and target direct superclass URIs]
 http://purl.obolibrary.org/obo/CHEBI_2637 # amikacin
 subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule
+http://purl.obolibrary.org/obo/CHEBI_3098 # bile acid
+subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule
 http://purl.obolibrary.org/obo/CHEBI_4431 # deoxyribonucleotide
 subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule
 http://purl.obolibrary.org/obo/CHEBI_4551 # digoxin
@@ -206,6 +208,8 @@ http://purl.obolibrary.org/obo/CHEBI_24875 # iron cation
 subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule
 http://purl.obolibrary.org/obo/CHEBI_25078 # luciferin
 subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule
+http://purl.obolibrary.org/obo/CHEBI_25555 # nitrogen atom
+subClassOf http://purl.obolibrary.org/obo/COB_0000011 # atom
 http://purl.obolibrary.org/obo/CHEBI_26710 # sodium chloride
 subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule
 http://purl.obolibrary.org/obo/CHEBI_27226 # uric acid
@@ -335,6 +339,8 @@ subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule
 http://purl.obolibrary.org/obo/CHEBI_59056 # EDTA methidiumpropylamide
 subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule
 http://purl.obolibrary.org/obo/CHEBI_59424 # bromophenol blue
+subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule
+http://purl.obolibrary.org/obo/CHEBI_60343 # 1-methyl-7-nitroisatoic anhydride
 subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule
 http://purl.obolibrary.org/obo/CHEBI_61057 # tacrolimus hydrate
 subClassOf http://purl.obolibrary.org/obo/COB_0000013 # molecule

--- a/src/ontology/OntoFox_outputs/ChEBI_imports.owl
+++ b/src/ontology/OntoFox_outputs/ChEBI_imports.owl
@@ -495,6 +495,7 @@
     <!-- http://purl.obolibrary.org/obo/CHEBI_25555 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25555">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000011"/>
         <obo:IAO_0000111>nitrogen atom</obo:IAO_0000111>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
         <rdfs:label>nitrogen atom</rdfs:label>
@@ -693,6 +694,7 @@
     <!-- http://purl.obolibrary.org/obo/CHEBI_3098 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_3098">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000013"/>
         <obo:IAO_0000111>bile acid</obo:IAO_0000111>
         <obo:IAO_0000115>Any member of a group of hydroxy-5β-cholanic acids occuring in bile, where they are present as the sodium salts of their amides with glycine or taurine. In mammals bile acids almost invariably have 5β-configuration.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
@@ -1371,6 +1373,7 @@
     <!-- http://purl.obolibrary.org/obo/CHEBI_60343 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_60343">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000013"/>
         <obo:IAO_0000111>1-methyl-7-nitroisatoic anhydride</obo:IAO_0000111>
         <obo:IAO_0000115>A 3,1-benzoxazin-1,4-dione having an &lt;em&gt;N&lt;/em&gt;-methyl substituent and a nitro group at the 7-position.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>


### PR DESCRIPTION
I noticed on Friday that there are a couple ChEBI terms currently floating at the top of the OBI hierarchy—at some point in some previous PR, those ChEBI terms were imported without the relevant subClassOf statements being added to the OntoFox config file. This PR adds those subClassOf statements to fix the problem.